### PR TITLE
Add score reveal overlay and polish onboarding

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1112,7 +1112,7 @@
       }
     </style>
   </head>
-  <body>
+  <body data-stage="call">
     <a href="#survey-section" class="skip-link"> Skip to survey </a>
     <button
       id="hud-toggle-btn"
@@ -1175,24 +1175,35 @@
           role="complementary"
           aria-label="Demo instructions"
         >
-          <span class="eyebrow">Instructions</span>
-          <h2>CXI Survey Demonstration</h2>
+          <button
+            type="button"
+            class="dismiss"
+            aria-label="Hide instructions"
+            data-dismiss-instructions
+          >
+            ×
+          </button>
+          <span class="eyebrow">Run of show</span>
+          <h2>Guide your buyer through the “magic minute”</h2>
           <p>
-            Click the <strong>Leave</strong> button in the call controls to launch
-            the coffee invite and feedback survey.
+            Press <strong>Leave</strong> when you’re ready—the invite, scoring
+            ritual and dashboard reveal all fire in under 60 seconds.
           </p>
           <ul>
-            <li><strong>Stay in character:</strong> the shell mimics a live Zoom.</li>
+            <li><strong>Stage the scene:</strong> point out the live-call chrome.</li>
             <li>
-              <strong>Accept:</strong> “Free coffee? Sure!” starts the survey with
-              $5 treat framing.
+              <strong>Accept</strong> for the latte hook and instant survey
+              handoff.
             </li>
             <li>
-              <strong>Later:</strong> “Remind me in an hour” queues a nudge email
-              (demo stateful).
+              <strong>Remind me</strong> to queue a smart nudge (watch for the
+              toast).
             </li>
           </ul>
-          <footer>Need a shortcut? Prefill via console: <code>autofill()</code>.</footer>
+          <footer>
+            Need a shortcut? Prefill via console: <code>autofill()</code> or
+            <code>scoreDemo()</code>.
+          </footer>
         </aside>
         <!-- Top bar -->
         <div class="cxi-topbar" role="toolbar" aria-label="Meeting status">
@@ -1259,6 +1270,20 @@
           aria-live="polite"
           class="small ats-status"
         ></span>
+      </div>
+      <div class="payload-preview">
+        <div class="row">
+          <span>Stage</span>
+          <span id="ats-stage">Panel</span>
+        </div>
+        <div class="row">
+          <span>Role</span>
+          <span id="ats-role">Backend SWE</span>
+        </div>
+        <div class="row">
+          <span>Token</span>
+          <span id="ats-token">cand_demo</span>
+        </div>
       </div>
       <pre id="ats-json" aria-live="polite">{}</pre>
     </aside>
@@ -1729,105 +1754,128 @@
       <!-- Summary Tab -->
       <div id="summary-tab">
         <div class="results-grid">
-          <div class="results-card">
-            <div class="score-display">
-              <div class="score-label">Net Sentiment Score</div>
-              <div class="score-value success" id="nss-display">+0.75</div>
-              <div class="band-indicator band-success" id="nss-band">
-                Positive
+          <div class="results-card highlight-card" id="results-hero-card">
+            <div class="results-hero">
+              <div class="score-orb" id="score-orb">
+                <span class="orb-value" id="orb-score">82</span>
+                <span class="orb-label">Composite Index</span>
+                <div class="orb-band">
+                  <span id="orb-band-label">Success</span>
+                </div>
+              </div>
+              <div class="hero-metric-grid">
+                <div class="metric-tile">
+                  <div>
+                    <div class="metric-label">Net Sentiment Score</div>
+                    <div class="metric-value" id="nss-display">+0.75</div>
+                  </div>
+                  <div class="band-indicator band-success" id="nss-band">
+                    Positive
+                  </div>
+                </div>
+                <div class="metric-tile">
+                  <div>
+                    <div class="metric-label">Quality Signal</div>
+                    <div class="metric-value" id="quality-score">92%</div>
+                  </div>
+                  <div class="band-indicator band-success" id="quality-band">
+                    Eligible
+                  </div>
+                </div>
+                <div class="metric-tile">
+                  <div>
+                    <div class="metric-label">Attention</div>
+                    <div class="metric-value" id="attention-score">4.8</div>
+                  </div>
+                  <div class="band-indicator band-success" id="attention-band">
+                    High
+                  </div>
+                </div>
               </div>
             </div>
+            <div
+              class="transcript-playback"
+              id="transcript-playback"
+              aria-live="polite"
+            ></div>
+          </div>
+
+          <div class="results-card" id="insight-card">
+            <h3>✨ Signal Highlights</h3>
             <div class="highlights-section">
-              <h4>Key Phrases</h4>
-              <div id="highlights-display">
+              <div id="highlights-display" class="highlight-stream">
                 <span class="highlight-item highlight-positive"
                   >clear communication</span
                 >
-                <span class="highlight-item highlight-positive"
-                  >responsive team</span
-                >
-                <span class="highlight-item highlight-negative"
-                  >slow feedback</span
-                >
               </div>
+            </div>
+            <div class="highlights-section mt-1">
+              <h4>Aspect Pulse</h4>
+              <div class="absa-tags" id="absa-display"></div>
             </div>
           </div>
 
-          <div class="results-card">
-            <div class="score-display">
-              <div class="score-label">Composite Index</div>
-              <div class="score-value success" id="index-display">0.82</div>
-              <div class="band-indicator band-success" id="index-band">
-                Success
+          <div class="results-card" id="summary-card">
+            <h3>📝 Narrative &amp; Coaching</h3>
+            <div id="summary-text">
+              <p>
+                <strong>Summary:</strong>
+                <span id="response-summary"
+                  >Positive experience at panel stage. Strengths: communication,
+                  clarity. Areas for improvement: feedback timeliness.</span
+                >
+              </p>
+              <div class="task-coaching">
+                <strong>Coaching Cue:</strong>
+                <span id="coaching-cue"
+                  >Set feedback SLA ≤3 business days for panel stage.</span
+                >
               </div>
-            </div>
-            <div class="highlights-section">
-              <h4>ABSA Analysis</h4>
-              <div class="absa-tags" id="absa-display">
-                <span class="absa-tag absa-positive">Communication</span>
-                <span class="absa-tag absa-positive">Clarity</span>
-                <span class="absa-tag absa-negative">Feedback Timeline</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="results-card">
-          <h3>📝 Summary & Coaching</h3>
-          <div id="summary-text">
-            <p>
-              <strong>Summary:</strong>
-              <span id="response-summary"
-                >Positive experience at panel stage. Strengths: communication,
-                clarity. Areas for improvement: feedback timeliness.</span
-              >
-            </p>
-            <div class="task-coaching">
-              <strong>Coaching Cue:</strong>
-              <span id="coaching-cue"
-                >Set feedback SLA ≤3 business days for panel stage.</span
-              >
-            </div>
-            <div id="quality-block" class="mt-1" hidden>
-              <div class="small muted" id="quality-flags"></div>
-              <div class="quality-row">
-                <div id="results-live" aria-live="polite" aria-atomic="true">
-                  <span id="quality-badge" class="quality-badge"
-                    ><svg aria-hidden="true" width="14" height="14">
-                      <use href="#icon-info" />
-                    </svg>
-                    <span class="qb-text">Quality: --</span></span
-                  >
+              <div id="quality-block" class="mt-1" hidden>
+                <div class="small muted" id="quality-flags"></div>
+                <div class="quality-row">
+                  <div id="results-live" aria-live="polite" aria-atomic="true">
+                    <span id="quality-badge" class="quality-badge"
+                      ><svg aria-hidden="true" width="14" height="14">
+                        <use href="#icon-info" />
+                      </svg>
+                      <span class="qb-text">Quality: --</span></span
+                    >
+                  </div>
+                  <span id="incentive-eligibility" class="small ml-1"></span>
                 </div>
-                <span id="incentive-eligibility" class="small ml-1"></span>
               </div>
             </div>
-          </div>
-          <div class="mt-1">
-            <button class="btn btn-primary" onclick="pushToDashboard()">
-              Push to Dashboard
-            </button>
-            <button class="btn btn-ghost" onclick="resetDemo()">
-              Reset Sample
-            </button>
-          </div>
-        </div>
-
-        <div class="results-card" id="ctr-card">
-          <div class="ctr-hdr">
-            <h3 class="no-m">📈 Invite CTR</h3>
-            <div>
-              <label class="small" for="ctr-days-select">Range</label>
-              <select id="ctr-days-select" class="small" aria-label="CTR range">
-                <option value="7" selected>Last 7 days</option>
-                <option value="14">Last 14 days</option>
-                <option value="30">Last 30 days</option>
-              </select>
+            <div class="mt-1 action-row">
+              <button class="btn btn-primary" onclick="pushToDashboard()">
+                Push to Dashboard
+              </button>
+              <button class="btn btn-ghost" onclick="resetDemo()">
+                Reset Sample
+              </button>
             </div>
           </div>
-          <div class="muted small">Views vs Accepts by invite variant</div>
-          <div id="ctr-summary" class="mt-1 muted">Loading…</div>
-          <div id="ctr-breakdown" class="mt-1 small"></div>
+
+          <div class="results-card" id="ctr-card">
+            <div class="ctr-hdr">
+              <h3 class="no-m">📈 Invite CTR</h3>
+              <div>
+                <label class="small" for="ctr-days-select">Range</label>
+                <select
+                  id="ctr-days-select"
+                  class="small"
+                  aria-label="CTR range"
+                >
+                  <option value="7" selected>Last 7 days</option>
+                  <option value="14">Last 14 days</option>
+                  <option value="30">Last 30 days</option>
+                </select>
+              </div>
+            </div>
+            <div class="muted small">Views vs Accepts by invite variant</div>
+            <div id="ctr-summary" class="mt-1 muted">Loading…</div>
+            <div id="ctr-breakdown" class="mt-1 small"></div>
+          </div>
         </div>
       </div>
 
@@ -1840,242 +1888,341 @@
             negative sentiment.
           </p>
 
-          <div class="heatmap-grid" id="heatmap-grid">
-            <!-- Headers -->
-            <div class="heatmap-header"></div>
-            <div class="heatmap-header">Applied</div>
-            <div class="heatmap-header">Recruiter</div>
-            <div class="heatmap-header">Hiring Mgr</div>
-            <div class="heatmap-header">Panel</div>
-            <div class="heatmap-header">Assignment</div>
-            <div class="heatmap-header">Offer</div>
-            <div class="heatmap-header">Rejected</div>
+        <div class="heatmap-grid" id="heatmap-grid">
+          <div class="heatmap-header"></div>
+          <div class="heatmap-header">Applied</div>
+          <div class="heatmap-header">Recruiter</div>
+          <div class="heatmap-header">Hiring Mgr</div>
+          <div class="heatmap-header">Panel</div>
+          <div class="heatmap-header">Assignment</div>
+          <div class="heatmap-header">Offer</div>
+          <div class="heatmap-header">Rejected</div>
 
-            <!-- Communication Row -->
-            <div class="heatmap-row-label">Communication</div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('communication', 'applied')"
-            >
-              +0.8
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('communication', 'recruiter')"
-            >
-              +0.6
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('communication', 'hiring_manager')"
-            >
-              +0.7
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('communication', 'panel')"
-            >
-              +0.5
-            </div>
-            <div
-              class="heatmap-cell heatmap-neutral"
-              onclick="showHeatmapDetail('communication', 'assignment')"
-            >
-              +0.2
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('communication', 'offer')"
-            >
-              +0.9
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('communication', 'rejected')"
-            >
-              -0.3
-            </div>
-
-            <!-- Scheduling Row -->
-            <div class="heatmap-row-label">Scheduling</div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('scheduling', 'applied')"
-            >
-              +0.9
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('scheduling', 'recruiter')"
-            >
-              +0.4
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('scheduling', 'hiring_manager')"
-            >
-              -0.2
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('scheduling', 'panel')"
-            >
-              -0.4
-            </div>
-            <div
-              class="heatmap-cell heatmap-neutral"
-              onclick="showHeatmapDetail('scheduling', 'assignment')"
-            >
-              +0.1
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('scheduling', 'offer')"
-            >
-              +0.7
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('scheduling', 'rejected')"
-            >
-              -0.6
-            </div>
-
-            <!-- Clarity Row -->
-            <div class="heatmap-row-label">Clarity</div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('clarity', 'applied')"
-            >
-              +0.6
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('clarity', 'recruiter')"
-            >
-              +0.8
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('clarity', 'hiring_manager')"
-            >
-              +0.3
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('clarity', 'panel')"
-            >
-              -0.1
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('clarity', 'assignment')"
-            >
-              -0.3
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('clarity', 'offer')"
-            >
-              +0.8
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('clarity', 'rejected')"
-            >
-              -0.5
-            </div>
-
-            <!-- Respect Row -->
-            <div class="heatmap-row-label">Respect</div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('respect', 'applied')"
-            >
-              +0.9
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('respect', 'recruiter')"
-            >
-              +0.7
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('respect', 'hiring_manager')"
-            >
-              +0.8
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('respect', 'panel')"
-            >
-              +0.6
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('respect', 'assignment')"
-            >
-              +0.4
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('respect', 'offer')"
-            >
-              +0.9
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('respect', 'rejected')"
-            >
-              -0.2
-            </div>
-
-            <!-- Feedback Timeline Row -->
-            <div class="heatmap-row-label">Feedback</div>
-            <div
-              class="heatmap-cell heatmap-neutral"
-              onclick="showHeatmapDetail('feedback', 'applied')"
-            >
-              +0.1
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('feedback', 'recruiter')"
-            >
-              -0.2
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('feedback', 'hiring_manager')"
-            >
-              -0.4
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('feedback', 'panel')"
-            >
-              -0.6
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('feedback', 'assignment')"
-            >
-              -0.8
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('feedback', 'offer')"
-            >
-              +0.5
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('feedback', 'rejected')"
-            >
-              -0.9
-            </div>
+          <div class="heatmap-row-label">Communication</div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="communication"
+            data-stage="applied"
+            data-label="Applied"
+            onclick="showHeatmapDetail('communication', 'applied')"
+          >
+            +0.8
           </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="communication"
+            data-stage="recruiter"
+            data-label="Recruiter"
+            onclick="showHeatmapDetail('communication', 'recruiter')"
+          >
+            +0.6
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="communication"
+            data-stage="hiring_manager"
+            data-label="Hiring Mgr"
+            onclick="showHeatmapDetail('communication', 'hiring_manager')"
+          >
+            +0.7
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="communication"
+            data-stage="panel"
+            data-label="Panel"
+            onclick="showHeatmapDetail('communication', 'panel')"
+          >
+            +0.5
+          </div>
+          <div
+            class="heatmap-cell heatmap-neutral"
+            data-aspect="communication"
+            data-stage="assignment"
+            data-label="Assignment"
+            onclick="showHeatmapDetail('communication', 'assignment')"
+          >
+            +0.2
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="communication"
+            data-stage="offer"
+            data-label="Offer"
+            onclick="showHeatmapDetail('communication', 'offer')"
+          >
+            +0.9
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="communication"
+            data-stage="rejected"
+            data-label="Rejected"
+            onclick="showHeatmapDetail('communication', 'rejected')"
+          >
+            -0.3
+          </div>
+
+          <div class="heatmap-row-label">Scheduling</div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="scheduling"
+            data-stage="applied"
+            data-label="Applied"
+            onclick="showHeatmapDetail('scheduling', 'applied')"
+          >
+            +0.9
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="scheduling"
+            data-stage="recruiter"
+            data-label="Recruiter"
+            onclick="showHeatmapDetail('scheduling', 'recruiter')"
+          >
+            +0.4
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="scheduling"
+            data-stage="hiring_manager"
+            data-label="Hiring Mgr"
+            onclick="showHeatmapDetail('scheduling', 'hiring_manager')"
+          >
+            -0.2
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="scheduling"
+            data-stage="panel"
+            data-label="Panel"
+            onclick="showHeatmapDetail('scheduling', 'panel')"
+          >
+            -0.4
+          </div>
+          <div
+            class="heatmap-cell heatmap-neutral"
+            data-aspect="scheduling"
+            data-stage="assignment"
+            data-label="Assignment"
+            onclick="showHeatmapDetail('scheduling', 'assignment')"
+          >
+            +0.1
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="scheduling"
+            data-stage="offer"
+            data-label="Offer"
+            onclick="showHeatmapDetail('scheduling', 'offer')"
+          >
+            +0.7
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="scheduling"
+            data-stage="rejected"
+            data-label="Rejected"
+            onclick="showHeatmapDetail('scheduling', 'rejected')"
+          >
+            -0.6
+          </div>
+
+          <div class="heatmap-row-label">Clarity</div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="clarity"
+            data-stage="applied"
+            data-label="Applied"
+            onclick="showHeatmapDetail('clarity', 'applied')"
+          >
+            +0.6
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="clarity"
+            data-stage="recruiter"
+            data-label="Recruiter"
+            onclick="showHeatmapDetail('clarity', 'recruiter')"
+          >
+            +0.8
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="clarity"
+            data-stage="hiring_manager"
+            data-label="Hiring Mgr"
+            onclick="showHeatmapDetail('clarity', 'hiring_manager')"
+          >
+            +0.3
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="clarity"
+            data-stage="panel"
+            data-label="Panel"
+            onclick="showHeatmapDetail('clarity', 'panel')"
+          >
+            -0.1
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="clarity"
+            data-stage="assignment"
+            data-label="Assignment"
+            onclick="showHeatmapDetail('clarity', 'assignment')"
+          >
+            -0.3
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="clarity"
+            data-stage="offer"
+            data-label="Offer"
+            onclick="showHeatmapDetail('clarity', 'offer')"
+          >
+            +0.8
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="clarity"
+            data-stage="rejected"
+            data-label="Rejected"
+            onclick="showHeatmapDetail('clarity', 'rejected')"
+          >
+            -0.5
+          </div>
+
+          <div class="heatmap-row-label">Respect</div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="respect"
+            data-stage="applied"
+            data-label="Applied"
+            onclick="showHeatmapDetail('respect', 'applied')"
+          >
+            +0.9
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="respect"
+            data-stage="recruiter"
+            data-label="Recruiter"
+            onclick="showHeatmapDetail('respect', 'recruiter')"
+          >
+            +0.7
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="respect"
+            data-stage="hiring_manager"
+            data-label="Hiring Mgr"
+            onclick="showHeatmapDetail('respect', 'hiring_manager')"
+          >
+            +0.8
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="respect"
+            data-stage="panel"
+            data-label="Panel"
+            onclick="showHeatmapDetail('respect', 'panel')"
+          >
+            +0.6
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="respect"
+            data-stage="assignment"
+            data-label="Assignment"
+            onclick="showHeatmapDetail('respect', 'assignment')"
+          >
+            +0.4
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="respect"
+            data-stage="offer"
+            data-label="Offer"
+            onclick="showHeatmapDetail('respect', 'offer')"
+          >
+            +0.9
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="respect"
+            data-stage="rejected"
+            data-label="Rejected"
+            onclick="showHeatmapDetail('respect', 'rejected')"
+          >
+            -0.2
+          </div>
+
+          <div class="heatmap-row-label">Feedback</div>
+          <div
+            class="heatmap-cell heatmap-neutral"
+            data-aspect="feedback"
+            data-stage="applied"
+            data-label="Applied"
+            onclick="showHeatmapDetail('feedback', 'applied')"
+          >
+            +0.1
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="feedback"
+            data-stage="recruiter"
+            data-label="Recruiter"
+            onclick="showHeatmapDetail('feedback', 'recruiter')"
+          >
+            -0.2
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="feedback"
+            data-stage="hiring_manager"
+            data-label="Hiring Mgr"
+            onclick="showHeatmapDetail('feedback', 'hiring_manager')"
+          >
+            -0.4
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="feedback"
+            data-stage="panel"
+            data-label="Panel"
+            onclick="showHeatmapDetail('feedback', 'panel')"
+          >
+            -0.6
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="feedback"
+            data-stage="assignment"
+            data-label="Assignment"
+            onclick="showHeatmapDetail('feedback', 'assignment')"
+          >
+            -0.8
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="feedback"
+            data-stage="offer"
+            data-label="Offer"
+            onclick="showHeatmapDetail('feedback', 'offer')"
+          >
+            +0.5
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="feedback"
+            data-stage="rejected"
+            data-label="Rejected"
+            onclick="showHeatmapDetail('feedback', 'rejected')"
+          >
+            -0.9
+          </div>
+        </div>
         </div>
 
         <div id="heatmap-detail" class="results-card hidden">
@@ -2123,10 +2270,45 @@
           </div>
         </div>
 
+        <div class="results-card roster-card" id="interviewer-roster">
+          <h4>Interview Team Coaching Focus</h4>
+          <ul>
+            <li>
+              <span class="name">Jason R.</span>
+              <span class="goal">Weekly goal: SLA &lt; 48 hours feedback.</span>
+            </li>
+            <li>
+              <span class="name">Jess D.</span>
+              <span class="goal"
+                >Communication must clearly outline the role and agenda.</span
+              >
+            </li>
+            <li>
+              <span class="name">Priya K.</span>
+              <span class="goal"
+                >Ensure technical debriefs include action-ready notes for hiring
+                managers.</span
+              >
+            </li>
+            <li>
+              <span class="name">Amelia S.</span>
+              <span class="goal"
+                >Build consistent rubric talk-throughs to set candidate
+                expectations.</span
+              >
+            </li>
+          </ul>
+        </div>
+
         <div class="task-list" id="task-list">
           <div class="task-header">Active Tasks (3)</div>
 
-          <div class="task-item" data-stage="panel" data-priority="high">
+          <div
+            class="task-item"
+            data-stage="panel"
+            data-priority="high"
+            data-age-minutes="120"
+          >
             <div class="task-meta">
               <div>
                 <span class="task-priority priority-high">High</span>
@@ -2143,7 +2325,12 @@
             </div>
           </div>
 
-          <div class="task-item" data-stage="recruiter" data-priority="medium">
+          <div
+            class="task-item"
+            data-stage="recruiter"
+            data-priority="medium"
+            data-age-minutes="300"
+          >
             <div class="task-meta">
               <div>
                 <span class="task-priority priority-medium">Medium</span>
@@ -2159,7 +2346,12 @@
             </div>
           </div>
 
-          <div class="task-item" data-stage="offer" data-priority="low">
+          <div
+            class="task-item"
+            data-stage="offer"
+            data-priority="low"
+            data-age-minutes="1440"
+          >
             <div class="task-meta">
               <div>
                 <span class="task-priority priority-low">Low</span>
@@ -2208,6 +2400,120 @@
       </div>
     </div>
 
+    <div
+      id="score-reveal"
+      class="score-reveal"
+      role="dialog"
+      aria-modal="true"
+      aria-live="assertive"
+      hidden
+    >
+      <div class="score-reveal__panel">
+        <button
+          type="button"
+          class="score-reveal__close"
+          data-close-reveal
+          aria-label="Dismiss score reveal"
+        >
+          ×
+        </button>
+        <span class="score-reveal__eyebrow">Magic minute</span>
+        <h2 class="score-reveal__headline">Signal spell complete ✨</h2>
+        <div class="score-reveal__grid">
+          <div class="score-reveal__metric">
+            <span class="label">Composite Index</span>
+            <span class="value" data-reveal-index>0</span>
+          </div>
+          <div class="score-reveal__metric">
+            <span class="label">Net Sentiment</span>
+            <span class="value" data-reveal-nss>+0.00</span>
+          </div>
+          <div class="score-reveal__metric">
+            <span class="label">Quality Gate</span>
+            <span class="value" data-reveal-quality>0%</span>
+          </div>
+        </div>
+        <div class="score-reveal__summary" data-reveal-summary>
+          Candidate sentiment landed positive at the panel stage. Strengths:
+          communication &amp; clarity. Focus next: feedback cadence.
+        </div>
+        <div class="score-reveal__stage">
+          <span data-reveal-stage>Panel Interview</span>
+          <span class="band-pill" data-reveal-band>Success</span>
+        </div>
+        <div class="score-reveal__aspects" data-reveal-aspects>
+          <span>Communication</span><span>Clarity</span>
+        </div>
+        <div class="score-reveal__sentence" data-reveal-sentence>
+          Panel started on time with clear introductions and respectful tone
+          throughout.
+        </div>
+        <div class="score-reveal__actions">
+          <button type="button" class="btn btn-ghost" data-close-reveal>
+            Skip animation
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-reveal-open-dashboard
+          >
+            Open full dashboard
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Dashboard share modal -->
+    <div
+      id="dashboard-modal"
+      class="modal-overlay"
+      role="presentation"
+      hidden
+    >
+      <div
+        class="modal-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dashboard-modal-title"
+      >
+        <header>
+          <h3 id="dashboard-modal-title">Push to CXI Dashboard</h3>
+          <button
+            type="button"
+            class="btn btn-ghost"
+            data-close-dashboard
+            aria-label="Close push-to-dashboard modal"
+          >
+            ×
+          </button>
+        </header>
+        <div id="dashboard-modal-summary" class="muted small">
+          Coaching tasks staged for review.
+        </div>
+        <div class="modal-body">
+          <div class="checklist" id="dashboard-task-list"></div>
+          <div>
+            <h4>Share instantly</h4>
+            <div class="share-buttons">
+              <button class="btn btn-primary" data-share="email">Email</button>
+              <button class="btn btn-primary" data-share="slack">Slack</button>
+              <button class="btn btn-primary" data-share="teams">Teams</button>
+              <button class="btn btn-primary" data-share="pdf">Export PDF</button>
+            </div>
+            <div class="share-preview" id="share-preview" hidden></div>
+          </div>
+        </div>
+        <footer>
+          <button class="btn btn-ghost" data-action="copy-checklist">
+            Copy selected tasks
+          </button>
+          <button class="btn btn-primary" data-close-dashboard>Done</button>
+        </footer>
+      </div>
+    </div>
+
+    <div id="toast-layer" class="toast-layer" aria-live="polite"></div>
+
     <script>
       let currentStage = "call";
       let isRecording = false;
@@ -2235,6 +2541,7 @@
       // Zoom Call Functions
       function showStage(stage) {
         currentStage = stage;
+        document.body.dataset.stage = stage;
         // Hide all major views
         ["interview-view", "survey-view", "results-view"].forEach((id) => {
           const el = document.getElementById(id);
@@ -2254,6 +2561,10 @@
         // Auto-load summary metrics when landing on results
         if (stage === "results" && typeof loadCtrMetrics === "function") {
           loadCtrMetrics();
+          requestAnimationFrame(() => {
+            document.getElementById("results-view")?.scrollTo?.(0, 0);
+            window.scrollTo({ top: 0, behavior: "smooth" });
+          });
         }
 
         // Update hash
@@ -2654,6 +2965,24 @@
         }, 1000);
       }
 
+      function showToast(message, tone = "positive") {
+        const layer = document.getElementById("toast-layer");
+        if (!layer) return;
+        const toast = document.createElement("div");
+        toast.className = "toast";
+        toast.dataset.tone = tone;
+        toast.innerHTML = `<span>${message}</span><button type="button" class="toast-close" aria-label="Dismiss notification">×</button>`;
+        const closeBtn = toast.querySelector(".toast-close");
+        const dismiss = () => {
+          toast.classList.add("hiding");
+          setTimeout(() => toast.remove(), 200);
+        };
+        closeBtn?.addEventListener("click", dismiss);
+        layer.appendChild(toast);
+        setTimeout(dismiss, 4200);
+      }
+      window.__cxToast = showToast;
+
       /* Inline fallback functions for when modules don't load properly */
       function updateWordCount(textareaId, countId) {
         const textarea = document.getElementById(textareaId);
@@ -2755,7 +3084,6 @@
       }
 
       function enforceExactWords(textareaId, countId, exact) {
-        console.log('enforceExactWords called (fallback)');
         const ta = document.getElementById(textareaId);
         if (!ta) return;
         const words = ta.value.trim().match(/\S+/g) || [];
@@ -2778,6 +3106,53 @@
       
       document.addEventListener("DOMContentLoaded", function () {
         init();
+        const inlineCta = document.getElementById("inline-cta");
+        if (inlineCta && inlineCta.dataset.managed !== "true") {
+          inlineCta.dataset.managed = "true";
+          let fadeTimer;
+          let hideTimer;
+          const clearTimers = () => {
+            clearTimeout(fadeTimer);
+            clearTimeout(hideTimer);
+          };
+          const scheduleTimers = () => {
+            clearTimers();
+            fadeTimer = setTimeout(() => {
+              inlineCta.setAttribute("data-state", "fading");
+            }, 9000);
+            hideTimer = setTimeout(() => {
+              inlineCta.setAttribute("data-hidden", "true");
+            }, 15000);
+          };
+          const revealPlacard = () => {
+            inlineCta.removeAttribute("data-state");
+            inlineCta.removeAttribute("data-hidden");
+          };
+          const dismissPlacard = () => {
+            clearTimers();
+            inlineCta.removeAttribute("data-state");
+            inlineCta.setAttribute("data-hidden", "true");
+          };
+          scheduleTimers();
+          inlineCta.addEventListener("mouseenter", () => {
+            revealPlacard();
+            clearTimers();
+          });
+          inlineCta.addEventListener("focusin", () => {
+            revealPlacard();
+            clearTimers();
+          });
+          inlineCta.addEventListener("mouseleave", () => {
+            if (inlineCta.getAttribute("data-hidden") === "true") return;
+            scheduleTimers();
+          });
+          inlineCta.addEventListener("focusout", () => {
+            if (!inlineCta.contains(document.activeElement)) scheduleTimers();
+          });
+          inlineCta
+            .querySelector("[data-dismiss-instructions]")
+            ?.addEventListener("click", dismissPlacard);
+        }
         // Show HUD toggle only when ?debug=1
         try {
           const debug = new URL(location.href).searchParams.get("debug");
@@ -3478,7 +3853,7 @@
         .getElementById("cxi-cta-remind")
         .addEventListener("click", () => {
           const st = getNudgeState();
-          const plan = [4, 24, 72];
+          const plan = [1, 24, 72];
           const nextIdx = Math.min(st.count, plan.length - 1);
           if (typeof track === "function")
             track("remind", {
@@ -3487,6 +3862,11 @@
               variant: window.__cxiVariantKey,
             });
           scheduleNudge(plan[nextIdx]);
+          if (typeof showToast === "function") {
+            const hours = plan[nextIdx];
+            const label = hours === 1 ? "one hour" : `${hours} hours`;
+            showToast(`We\'ll send a nudge in ${label}.`, "warning");
+          }
           closeInvite();
         });
       document
@@ -3536,6 +3916,13 @@
 
       // ATS webhook simulator
       function showATSWebhook(stage, role, token) {
+        let debugMode = false;
+        try {
+          debugMode = new URL(location.href).searchParams.get("debug") === "1";
+        } catch (_) {
+          debugMode = false;
+        }
+        if (!debugMode) return;
         const payload = {
           event: "candidate_feedback_invite",
           stage,
@@ -3547,6 +3934,12 @@
         };
         const el = document.getElementById("ats-json");
         const panel = document.getElementById("ats-panel");
+        const stageEl = document.getElementById("ats-stage");
+        const roleEl = document.getElementById("ats-role");
+        const tokenEl = document.getElementById("ats-token");
+        if (stageEl) stageEl.textContent = stage;
+        if (roleEl) roleEl.textContent = role;
+        if (tokenEl) tokenEl.textContent = payload.candidate_token;
         if (el && panel) {
           el.textContent = JSON.stringify(payload, null, 2);
           panel.hidden = false;

--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -8,7 +8,12 @@ import {
   showResultsTab,
   updateProgress,
 } from "./survey.js";
-import { performanceMark } from "./utils.js";
+import {
+  animateNumber,
+  performanceMark,
+  seededRandom,
+  typewriter,
+} from "./utils.js";
 
 window.showResultsTab = showResultsTab;
 if (typeof window.openInvite !== "function") {
@@ -26,6 +31,9 @@ function ensureDashboard() {
     window.showHeatmapDetail = mod.showHeatmapDetail;
     window.filterTasks = mod.filterTasks;
     window.pushToDashboard = mod.pushToDashboard;
+    if (mod.updateRosterHighlight) {
+      window.updateRosterHighlight = mod.updateRosterHighlight;
+    }
     window.__dashboardLoaded = true;
   });
 }
@@ -45,6 +53,196 @@ function initCandidateToken() {
   const existing = url.searchParams.get("token");
   window.CANDIDATE_TOKEN =
     existing || "cand_" + Math.random().toString(36).slice(2, 10).toLowerCase();
+}
+
+let instructionTimers = { fade: 0, hide: 0 };
+function setupInstructionPlacard() {
+  const placard = document.getElementById("inline-cta");
+  if (!placard) return;
+  if (placard.dataset.managed === "true") return;
+  placard.dataset.managed = "true";
+  const clearTimers = () => {
+    clearTimeout(instructionTimers.fade);
+    clearTimeout(instructionTimers.hide);
+  };
+  const schedule = () => {
+    clearTimers();
+    instructionTimers.fade = window.setTimeout(() => {
+      placard.setAttribute("data-state", "fading");
+    }, 9000);
+    instructionTimers.hide = window.setTimeout(() => {
+      placard.setAttribute("data-hidden", "true");
+    }, 15000);
+  };
+  const reveal = () => {
+    placard.removeAttribute("data-state");
+    placard.removeAttribute("data-hidden");
+  };
+  const dismiss = () => {
+    clearTimers();
+    placard.removeAttribute("data-state");
+    placard.setAttribute("data-hidden", "true");
+  };
+  schedule();
+  placard.addEventListener("mouseenter", () => {
+    reveal();
+    clearTimers();
+  });
+  placard.addEventListener("focusin", () => {
+    reveal();
+    clearTimers();
+  });
+  placard.addEventListener("mouseleave", () => {
+    if (placard.getAttribute("data-hidden") === "true") return;
+    schedule();
+  });
+  placard.addEventListener("focusout", () => {
+    if (!placard.contains(document.activeElement)) schedule();
+  });
+  placard
+    .querySelector("[data-dismiss-instructions]")
+    ?.addEventListener("click", dismiss);
+}
+
+let scoreRevealEl = null;
+const scoreRevealTimers = new Set();
+
+function clearScoreRevealTimers() {
+  scoreRevealTimers.forEach((id) => clearTimeout(id));
+  scoreRevealTimers.clear();
+}
+
+function hideScoreReveal() {
+  if (!scoreRevealEl) return;
+  clearScoreRevealTimers();
+  scoreRevealEl.classList.remove("is-visible");
+  scoreRevealEl.setAttribute("aria-hidden", "true");
+  const el = scoreRevealEl;
+  window.setTimeout(() => {
+    el.hidden = true;
+  }, 240);
+}
+
+function setupScoreReveal() {
+  scoreRevealEl = document.getElementById("score-reveal");
+  if (!scoreRevealEl) return;
+  scoreRevealEl.hidden = true;
+  scoreRevealEl.setAttribute("aria-hidden", "true");
+  scoreRevealEl.addEventListener("click", (evt) => {
+    if (evt.target === scoreRevealEl) hideScoreReveal();
+  });
+  scoreRevealEl
+    .querySelectorAll("[data-close-reveal]")
+    .forEach((btn) => btn.addEventListener("click", hideScoreReveal));
+  const jumpBtn = scoreRevealEl.querySelector(
+    "[data-reveal-open-dashboard]",
+  );
+  if (jumpBtn) {
+    jumpBtn.addEventListener("click", () => {
+      hideScoreReveal();
+      showResultsTab("summary");
+      document
+        .getElementById("results-view")
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  }
+  window.dismissScoreReveal = hideScoreReveal;
+}
+
+function highlightRevealSentence(sentence = "", aspects = []) {
+  if (!scoreRevealEl) return;
+  const target = scoreRevealEl.querySelector("[data-reveal-sentence]");
+  if (!target) return;
+  const cleaned = (sentence || "").trim();
+  if (!cleaned) {
+    target.textContent =
+      "NSS translator will light up once a candidate story streams in.";
+    return;
+  }
+  target.textContent = cleaned;
+  const keywords = (aspects || [])
+    .map((aspect) => formatAspect(aspect).toLowerCase())
+    .filter(Boolean)
+    .flatMap((word) => [word, word.replace(/\s+/g, "")]);
+  const timer = window.setTimeout(() => {
+    const tokens = cleaned.split(/(\s+)/);
+    target.innerHTML = tokens
+      .map((token) => {
+        const normalized = token
+          .toLowerCase()
+          .replace(/[^a-z0-9]/g, "");
+        const hit = keywords.some((kw) =>
+          normalized.includes(kw.replace(/[^a-z0-9]/g, "")),
+        );
+        return hit && token.trim()
+          ? `<mark>${token}</mark>`
+          : token;
+      })
+      .join("");
+  }, 720);
+  scoreRevealTimers.add(timer);
+}
+
+function triggerScoreReveal(context) {
+  if (!scoreRevealEl) return;
+  clearScoreRevealTimers();
+  scoreRevealEl.hidden = false;
+  scoreRevealEl.setAttribute("aria-hidden", "false");
+  requestAnimationFrame(() => scoreRevealEl.classList.add("is-visible"));
+  const indexEl = scoreRevealEl.querySelector("[data-reveal-index]");
+  const nssEl = scoreRevealEl.querySelector("[data-reveal-nss]");
+  const qualityEl = scoreRevealEl.querySelector("[data-reveal-quality]");
+  if (indexEl)
+    animateNumber(indexEl, {
+      from: 0,
+      to: Number(context.index || 0) * 100,
+      duration: 900,
+      decimals: 0,
+    });
+  if (nssEl)
+    animateNumber(nssEl, {
+      from: 0,
+      to: Number(context.nss || 0),
+      duration: 900,
+      decimals: 2,
+      prefix: context.nss >= 0 ? "+" : "",
+    });
+  if (qualityEl)
+    animateNumber(qualityEl, {
+      from: 0,
+      to: Number(context.quality || 0) * 100,
+      duration: 900,
+      decimals: 0,
+      suffix: "%",
+    });
+  const summaryEl = scoreRevealEl.querySelector("[data-reveal-summary]");
+  if (summaryEl) {
+    summaryEl.textContent = context.summary || "Fresh signal incoming.";
+    summaryEl.classList.remove("is-highlighted");
+    const t = window.setTimeout(
+      () => summaryEl.classList.add("is-highlighted"),
+      520,
+    );
+    scoreRevealTimers.add(t);
+  }
+  const stageEl = scoreRevealEl.querySelector("[data-reveal-stage]");
+  if (stageEl) stageEl.textContent = formatStage(context.stage);
+  const bandEl = scoreRevealEl.querySelector("[data-reveal-band]");
+  if (bandEl)
+    bandEl.textContent =
+      context.band || (context.index >= 0.7 ? "Success" : "Watch");
+  const aspectsEl = scoreRevealEl.querySelector("[data-reveal-aspects]");
+  if (aspectsEl) {
+    const aspects = Array.isArray(context.aspects) ? context.aspects : [];
+    const chips = aspects
+      .slice(0, 4)
+      .map((aspect) => `<span>${formatAspect(aspect)}</span>`)
+      .join("");
+    aspectsEl.innerHTML = chips || '<span>Candidate Delight</span>';
+  }
+  highlightRevealSentence(context.sentence, context.aspects);
+  const hideTimer = window.setTimeout(hideScoreReveal, 10000);
+  scoreRevealTimers.add(hideTimer);
 }
 
 function wireSurvey() {
@@ -117,6 +315,7 @@ function wireSubmission() {
   });
 }
 
+
 function displayResults(data) {
   performanceMark("results_display");
   if (typeof window.showStage === "function") {
@@ -127,103 +326,329 @@ function displayResults(data) {
     const resultsView = document.getElementById("results-view");
     if (resultsView) resultsView.classList.remove("hidden");
   }
-  const { bands = {}, composite_index = 0 } = data;
-  const overallEl = qs("overall-score");
-  if (overallEl)
-    overallEl.textContent = (composite_index * 100).toFixed(0) + "";
-  qs("band-overall").textContent = bands.overall || "N/A";
-  qs("band-fairness").textContent = bands.fairness || "N/A";
-  qs("band-sentiment").textContent = bands.sentiment || "N/A";
-  qs("band-rigor").textContent = bands.rigor || "N/A";
-  qs("band-speed").textContent = bands.speed || "N/A";
-  qs("band-clarity").textContent = bands.clarity || "N/A";
-  qs("band-trust").textContent = bands.trust || "N/A";
 
-  // Heatmap now rendered lazily when heatmap tab first viewed.
+  requestAnimationFrame(() => {
+    const resultsView = document.getElementById("results-view");
+    resultsView?.scrollIntoView({ behavior: "smooth", block: "start" });
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  });
+
   showResultsTab("summary");
 
-  // Quality badge integration
-  try {
-    const qBlock = qs("quality-block");
-    if (qBlock && data.quality_score !== undefined) {
-      qBlock.hidden = false;
-      const badge = qs("quality-badge");
-      const elig = qs("incentive-eligibility");
-      const flagsEl = qs("quality-flags");
-      const score = data.quality_score;
-      let cls = "";
-      if (score < 0.55) cls = "risk";
-      else if (score < 0.75) cls = "warn";
-      if (badge) {
-        badge.className = "quality-badge " + cls;
-        // Ensure structure: <svg><use></use></svg> <span class="qb-text">...</span>
-        let svg = badge.querySelector("svg");
-        if (!svg) {
-          svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-          svg.setAttribute("width", "14");
-          svg.setAttribute("height", "14");
-          svg.setAttribute("aria-hidden", "true");
-          const use = document.createElementNS(
-            "http://www.w3.org/2000/svg",
-            "use"
-          );
-          svg.appendChild(use);
-          badge.prepend(svg);
-        }
-        const useEl = svg.querySelector("use");
-        const icon =
-          cls === "risk"
-            ? "#icon-risk"
-            : cls === "warn"
-              ? "#icon-warn"
-              : "#icon-check";
-        if (useEl) useEl.setAttribute("href", icon);
-        let textSpan = badge.querySelector(".qb-text");
-        if (!textSpan) {
-          textSpan = document.createElement("span");
-          textSpan.className = "qb-text";
-          badge.appendChild(textSpan);
-        }
-        textSpan.textContent = `Quality: ${(score * 100).toFixed(0)}%`;
-        // Build tooltip with core heuristics if provided
-        const q = data.quality || {};
-        const tipParts = [];
-        if (typeof q.diversity === "number")
-          tipParts.push(`Diversity ${(q.diversity * 100).toFixed(0)}%`);
-        if (typeof q.longest_run === "number")
-          tipParts.push(`Longest Run ${q.longest_run}`);
-        if (typeof q.non_lexical_ratio === "number")
-          tipParts.push(`Non-lex ${(q.non_lexical_ratio * 100).toFixed(0)}%`);
-        if (typeof q.gibberish_score === "number")
-          tipParts.push(`Gibberish ${(q.gibberish_score * 100).toFixed(0)}%`);
-        if (typeof q.common_word_ratio === "number")
-          tipParts.push(`Common ${(q.common_word_ratio * 100).toFixed(0)}%`);
-        if (typeof q.entropy === "number")
-          tipParts.push(`Entropy ${q.entropy.toFixed(2)}`);
-        badge.title = "Quality Heuristics: " + tipParts.join(" • ");
-        badge.setAttribute("aria-label", badge.title);
-      }
-      if (flagsEl) {
-        const fl = data.quality_flags || [];
-        flagsEl.textContent = fl.length ? "Flags: " + fl.join(", ") : "";
-      }
-      if (elig) {
-        const eligible = !!data.incentive_eligible;
-        elig.textContent = eligible
-          ? "Eligible for eGift"
-          : "Ineligible (low-effort detected)";
-        elig.style.color = eligible ? "#34d399" : "#f87171";
-        elig.title = eligible
-          ? "Submission passes quality heuristics"
-          : "Submission failed one or more heuristics (e.g. repetition, low diversity, gibberish) and is excluded from incentive.";
-      }
-    }
-  } catch (e) {
-    // ignore quality rendering errors
+  const submission = window.__lastSubmission || {};
+  const bands = data.bands || {};
+  const compositeIndex = Number(data.composite_index || 0);
+  const textScore = Number(data.diagnostics?.textScore ?? 0.6);
+  const qualityScore = Number(data.quality_score ?? 0);
+  const attentionRaw = Number(submission.attention ?? 0);
+  const nss = Number(((textScore - 0.5) * 2).toFixed(2));
+
+  window.__lastResult = { ...data, nss };
+  window.CXI_LAST_INDEX = compositeIndex;
+
+  animateNumber(document.getElementById("orb-score"), {
+    from: 0,
+    to: compositeIndex * 100,
+    duration: 1200,
+    decimals: 0,
+  });
+  const orbBand = document.getElementById("orb-band-label");
+  if (orbBand) orbBand.textContent = bands.overall || "Success";
+
+  animateNumber(document.getElementById("nss-display"), {
+    from: 0,
+    to: nss,
+    duration: 1000,
+    decimals: 2,
+    prefix: nss >= 0 ? "+" : "",
+  });
+  setBandIndicator(
+    document.getElementById("nss-band"),
+    bands.sentiment || (nss >= 0 ? "Positive" : "Needs Work"),
+  );
+
+  animateNumber(document.getElementById("quality-score"), {
+    from: 0,
+    to: qualityScore * 100,
+    decimals: 0,
+    suffix: "%",
+  });
+  const qualityLabel =
+    qualityScore >= 0.75 ? "Eligible" : qualityScore >= 0.55 ? "Caution" : "Risk";
+  setBandIndicator(document.getElementById("quality-band"), qualityLabel);
+
+  animateNumber(document.getElementById("attention-score"), {
+    from: 0,
+    to: attentionRaw,
+    decimals: 1,
+  });
+  const attentionLabel =
+    attentionRaw >= 4 ? "High" : attentionRaw >= 3 ? "Medium" : "Low";
+  setBandIndicator(document.getElementById("attention-band"), attentionLabel);
+
+  renderHighlights(submission.aspects || [], data.quality_flags || []);
+
+  const summaryText = buildSummaryText(
+    submission.stage,
+    nss,
+    submission.aspects || [],
+    bands.overall,
+  );
+  const summaryEl = document.getElementById("response-summary");
+  if (summaryEl) typewriter(summaryEl, summaryText, { delay: 16 });
+
+  const cueText = buildCoachingCue(submission.aspects || [], submission.stage);
+  const cueEl = document.getElementById("coaching-cue");
+  if (cueEl) typewriter(cueEl, cueText, { delay: 20 });
+
+  renderTranscriptPlayback(
+    [submission.well, submission.better, submission.rant]
+      .filter(Boolean)
+      .join(" "),
+  );
+
+  const revealSentence =
+    (submission.rant || "").trim() ||
+    (submission.well || "").trim() ||
+    (submission.better || "").trim() ||
+    "";
+  triggerScoreReveal({
+    stage: submission.stage,
+    band: bands.overall,
+    index: compositeIndex,
+    nss,
+    quality: qualityScore,
+    summary: summaryText,
+    aspects: submission.aspects || [],
+    sentence: revealSentence,
+  });
+
+  updateQualityBlock(data);
+
+  const heatmap = synthesizeHeatmapMatrix(
+    compositeIndex,
+    textScore,
+    submission,
+  );
+  applyHeatmapMatrix(heatmap);
+  window.__lastResult.heatmap = heatmap;
+  ensureDashboard().then(() => {
+    window.updateRosterHighlight?.();
+  });
+}
+
+function setBandIndicator(element, label = "") {
+  if (!element) return;
+  element.classList.remove("band-success", "band-caution", "band-risk");
+  const lower = label.toLowerCase();
+  const cls = lower.includes("risk")
+    ? "band-risk"
+    : lower.includes("caution") || lower.includes("medium") || lower.includes("later")
+      ? "band-caution"
+      : "band-success";
+  element.classList.add(cls);
+  element.textContent = label;
+}
+
+function renderHighlights(aspects, flags) {
+  const highlightEl = document.getElementById("highlights-display");
+  const absaEl = document.getElementById("absa-display");
+  const items = Array.isArray(aspects) && aspects.length ? aspects : ["responsiveness", "clarity"];
+  if (highlightEl) {
+    highlightEl.innerHTML = items
+      .slice(0, 4)
+      .map((aspect) => {
+        const tone = aspect.includes("feedback") || flags.length ? "negative" : "positive";
+        return `<span class="highlight-item highlight-${tone}">${formatAspect(aspect)}</span>`;
+      })
+      .join("");
+  }
+  if (absaEl) {
+    absaEl.innerHTML = items
+      .slice(0, 5)
+      .map((aspect) => {
+        const tone = aspect.includes("feedback") ? "negative" : "positive";
+        return `<span class="absa-tag absa-${tone}">${formatAspect(aspect)}</span>`;
+      })
+      .join("");
   }
 }
 
-// Expose for legacy inline script references (until full cleanup complete)
+function buildSummaryText(stage, nss, aspects, band) {
+  const stageLabel = formatStage(stage);
+  const sentiment = band ? band.toLowerCase() : nss >= 0 ? "positive" : "risk";
+  const strengths = aspects.slice(0, 2).map(formatAspect);
+  const focus = aspects[2] ? formatAspect(aspects[2]) : "feedback cadence";
+  const strengthLabel = strengths.length ? strengths.join(" & ") : "responsiveness";
+  return `Candidate sentiment landed ${sentiment} at the ${stageLabel} stage. Strengths: ${strengthLabel}. Focus next: ${focus}.`;
+}
+
+function buildCoachingCue(aspects, stage) {
+  const focus = aspects.find((a) => a.includes("feedback")) || aspects[0] || "follow-up clarity";
+  const stageLabel = formatStage(stage);
+  return `Coach the ${stageLabel.toLowerCase()} crew on ${formatAspect(
+    focus,
+  )} and ship a follow-up within 24 hours.`;
+}
+
+function renderTranscriptPlayback(text) {
+  const target = document.getElementById("transcript-playback");
+  if (!target) return;
+  clearTimeout(target.__transcriptTimer);
+  const cleaned = text.trim();
+  if (!cleaned) {
+    target.textContent = "Transcript playback will appear here once scored.";
+    return;
+  }
+  const tokens = cleaned.split(/\s+/);
+  target.innerHTML = tokens
+    .map((word, idx) => `<span data-idx="${idx}">${word}</span>`)
+    .join(" ");
+  let index = 0;
+  const step = () => {
+    const prev = target.querySelector("span.active");
+    if (prev) prev.classList.remove("active");
+    const next = target.querySelector(`span[data-idx="${index}"]`);
+    if (next) {
+      next.classList.add("active");
+      next.scrollIntoView({ block: "nearest", inline: "center" });
+    }
+    index = (index + 1) % tokens.length;
+    target.__transcriptTimer = setTimeout(step, 240);
+  };
+  target.__transcriptTimer = setTimeout(step, 320);
+}
+
+function updateQualityBlock(data) {
+  try {
+    const qBlock = qs("quality-block");
+    if (!qBlock || data.quality_score === undefined) return;
+    qBlock.hidden = false;
+    const badge = qs("quality-badge");
+    const elig = qs("incentive-eligibility");
+    const flagsEl = qs("quality-flags");
+    const score = data.quality_score;
+    let cls = "";
+    if (score < 0.55) cls = "risk";
+    else if (score < 0.75) cls = "warn";
+    if (badge) {
+      badge.className = "quality-badge " + cls;
+      let svg = badge.querySelector("svg");
+      if (!svg) {
+        svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        svg.setAttribute("width", "14");
+        svg.setAttribute("height", "14");
+        svg.setAttribute("aria-hidden", "true");
+        const use = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        svg.appendChild(use);
+        badge.prepend(svg);
+      }
+      const useEl = svg.querySelector("use");
+      const icon =
+        cls === "risk"
+          ? "#icon-risk"
+          : cls === "warn"
+            ? "#icon-warn"
+            : "#icon-check";
+      if (useEl) useEl.setAttribute("href", icon);
+      let textSpan = badge.querySelector(".qb-text");
+      if (!textSpan) {
+        textSpan = document.createElement("span");
+        textSpan.className = "qb-text";
+        badge.appendChild(textSpan);
+      }
+      textSpan.textContent = `Quality: ${(score * 100).toFixed(0)}%`;
+    }
+    if (flagsEl) {
+      const fl = data.quality_flags || [];
+      flagsEl.textContent = fl.length ? `Flags: ${fl.join(", ")}` : "";
+    }
+    if (elig) {
+      const eligible = !!data.incentive_eligible;
+      elig.textContent = eligible
+        ? "Eligible for eGift"
+        : "Ineligible (low-effort detected)";
+      elig.style.color = eligible ? "#34d399" : "#f87171";
+    }
+  } catch (err) {
+    console.warn("quality block render error", err);
+  }
+}
+
+function synthesizeHeatmapMatrix(index, textScore, submission) {
+  const stages = [
+    "applied",
+    "recruiter",
+    "hiring_manager",
+    "panel",
+    "assignment",
+    "offer",
+    "rejected",
+  ];
+  const aspects = ["communication", "scheduling", "clarity", "respect", "feedback"];
+  const token = window.CANDIDATE_TOKEN || "seed";
+  const activeStage = submission.stage;
+  const matrix = {};
+  aspects.forEach((aspect, aIdx) => {
+    matrix[aspect] = {};
+    stages.forEach((stage, sIdx) => {
+      const noise = seededRandom(token, `${aspect}:${stage}`) - 0.5;
+      let value = index - 0.4 + noise * 0.6;
+      if (stage === activeStage) value += 0.12;
+      if (aspect === "feedback") value += (textScore - 0.5) * 0.5;
+      if (aspect === "respect") value += 0.05;
+      value += (aIdx - 2) * 0.03 + (sIdx - 3) * 0.015;
+      value = Math.max(-0.9, Math.min(0.9, value));
+      matrix[aspect][stage] = Number(value.toFixed(2));
+    });
+  });
+  return matrix;
+}
+
+function applyHeatmapMatrix(matrix) {
+  document
+    .querySelectorAll(".heatmap-cell[data-aspect]")
+    .forEach((cell) => {
+      const aspect = cell.dataset.aspect;
+      const stage = cell.dataset.stage;
+      const value = matrix?.[aspect]?.[stage];
+      if (typeof value !== "number") return;
+      const formatted = value >= 0 ? `+${value.toFixed(1)}` : value.toFixed(1);
+      cell.textContent = formatted;
+      cell.classList.remove(
+        "heatmap-positive",
+        "heatmap-negative",
+        "heatmap-neutral",
+      );
+      const cls =
+        value > 0.15
+          ? "heatmap-positive"
+          : value < -0.15
+            ? "heatmap-negative"
+            : "heatmap-neutral";
+      cell.classList.add(cls);
+    });
+}
+
+function formatStage(stage) {
+  const map = {
+    applied: "Applied",
+    recruiter: "Recruiter Screen",
+    hiring_manager: "Hiring Manager",
+    panel: "Panel",
+    assignment: "Take-home",
+    offer: "Offer",
+    rejected: "Closure",
+  };
+  return map[stage] || "Panel";
+}
+
+function formatAspect(aspect) {
+  return (aspect || "")
+    .replace(/[_-]/g, " ")
+    .replace(/\b\w/g, (m) => m.toUpperCase())
+    .trim();
+}
 window.displayResults = displayResults;
 
 function wireTabs() {
@@ -279,6 +704,8 @@ function init() {
   wireTabs();
   wireDLQButtons();
   wireMisc();
+  setupInstructionPlacard();
+  setupScoreReveal();
   restorePanels();
   performanceMark("app_init_end");
   // Auto-load panel metrics after idle

--- a/dist/js/dashboard.js
+++ b/dist/js/dashboard.js
@@ -1,17 +1,470 @@
-// Dashboard export and visualization functions
+const stageLabels = {
+  applied: "Applied",
+  recruiter: "Recruiter Screen",
+  hiring_manager: "Hiring Manager",
+  panel: "Panel Interview",
+  assignment: "Take-home",
+  offer: "Offer",
+  rejected: "Closure",
+};
 
-export function exportData() {
-  console.log('Data export triggered');
+const roster = [
+  { name: "Jason R.", goal: "SLA < 48 hours feedback." },
+  {
+    name: "Jess D.",
+    goal: "Clarify interview agenda and the role every time.",
+  },
+  {
+    name: "Priya K.",
+    goal: "Ship technical debriefs with action-ready notes.",
+  },
+  {
+    name: "Amelia S.",
+    goal: "Walk candidates through the rubric before questions start.",
+  },
+];
+
+const aspectPlaybook = {
+  communication: {
+    headline: "Tighten interview communication loops",
+    action:
+      "Share the interview outline before each call and recap decisions in writing within 24 hours.",
+  },
+  clarity: {
+    headline: "Level-set expectations on scope",
+    action:
+      "Align interviewers on what “great” looks like and provide concrete examples when answering role questions.",
+  },
+  feedback: {
+    headline: "Accelerate candidate feedback",
+    action:
+      "Commit to a 48-hour feedback SLA and template the debrief so panelists can add signal quickly.",
+  },
+  respect: {
+    headline: "Reinforce candidate-first etiquette",
+    action:
+      "Remind panelists to pause, let the candidate finish, and thank them for their time explicitly.",
+  },
+  scheduling: {
+    headline: "Smooth out the scheduling path",
+    action:
+      "Centralize interviewer availability and send consolidated invites with buffers for prep.",
+  },
+};
+
+const shareTemplates = {
+  email: (ctx, tasks) => `Subject: CXI coaching plan for ${ctx.stageLabel}
+
+Hi team,
+
+${ctx.summary}
+\nKey coaching moves:\n${tasks
+    .map((task) => `• ${task.headline} — ${task.action}`)
+    .join("\n")}\n\nLet’s close the loop by ${ctx.deadlineLabel}.`,
+  slack: (ctx, tasks) => `:sparkles: CXI pulse for ${ctx.stageLabel}\n${ctx.summary}\n${tasks
+    .map((task) => `• *${task.headline}* — ${task.action}`)
+    .join("\n")}\n${ctx.deadlineLabel}`,
+  teams: (ctx, tasks) => `CXI dashboard sync (${ctx.stageLabel})\n${ctx.summary}\nAction queue:\n${tasks
+    .map((task) => `• ${task.headline} — ${task.action}`)
+    .join("\n")}\nReply here with owners by ${ctx.deadlineLabel}.`,
+  pdf: (ctx, tasks) => `CXI Coaching Brief\nStage: ${ctx.stageLabel}\nNSS: ${ctx.nss.toFixed(2)}\nComposite Index: ${(ctx.index * 100).toFixed(0)}\n\nSummary\n${ctx.summary}\n\nCoaching Plan\n${tasks
+    .map((task, idx) => `${idx + 1}. ${task.headline}\n   ${task.action}`)
+    .join("\n")}\n\nDistribution List\n${roster.map((r) => `${r.name} — ${r.goal}`).join("\n")}`,
+};
+
+const aspectKeywords = {
+  communication: ["communicat", "explain", "responsive", "tone"],
+  clarity: ["clear", "clarity", "understand", "expect"],
+  feedback: ["feedback", "follow", "response", "update"],
+  respect: ["respect", "kind", "rude", "courteous"],
+  scheduling: ["schedule", "reschedule", "calendar", "timing"],
+};
+
+const timeframeMinutes = {
+  "7d": 7 * 24 * 60,
+  "30d": 30 * 24 * 60,
+  "90d": 90 * 24 * 60,
+};
+
+let modalOverlay;
+let checklistEl;
+let summaryEl;
+let sharePreviewEl;
+let currentTasks = [];
+let lastContext = null;
+
+function getToast() {
+  return window.__cxToast || window.showToast || null;
 }
 
-export function showHeatmapDetail(data) {
-  console.log('Heatmap detail:', data);
+function formatAspect(value = "") {
+  return value
+    .replace(/[_-]/g, " ")
+    .replace(/\b\w/g, (m) => m.toUpperCase())
+    .trim();
 }
 
-export function filterTasks(filter) {
-  console.log('Tasks filtered:', filter);
+function formatPriority(nss = 0, index = 0.6) {
+  if (nss < 0 || index < 0.5) return "high";
+  if (nss < 0.3 || index < 0.65) return "medium";
+  return "low";
 }
 
-export function pushToDashboard(data) {
-  console.log('Data pushed to dashboard:', data);
+function ensureModalBound() {
+  if (modalOverlay) return;
+  modalOverlay = document.getElementById("dashboard-modal");
+  checklistEl = document.getElementById("dashboard-task-list");
+  summaryEl = document.getElementById("dashboard-modal-summary");
+  sharePreviewEl = document.getElementById("share-preview");
+  if (!modalOverlay) return;
+
+  modalOverlay.addEventListener("click", (evt) => {
+    if (evt.target === modalOverlay) {
+      closeModal();
+    }
+  });
+  modalOverlay
+    .querySelectorAll("[data-close-dashboard]")
+    .forEach((btn) => btn.addEventListener("click", closeModal));
+  const shareButtons = modalOverlay.querySelectorAll("[data-share]");
+  shareButtons.forEach((btn) =>
+    btn.addEventListener("click", () => handleShare(btn.dataset.share)),
+  );
+  const copyBtn = modalOverlay.querySelector('[data-action="copy-checklist"]');
+  copyBtn?.addEventListener("click", copySelectedTasks);
 }
+
+function openModal() {
+  ensureModalBound();
+  if (!modalOverlay) return;
+  modalOverlay.hidden = false;
+  requestAnimationFrame(() => {
+    modalOverlay.classList.add("visible");
+  });
+}
+
+function closeModal() {
+  if (!modalOverlay) return;
+  modalOverlay.classList.remove("visible");
+  setTimeout(() => {
+    modalOverlay.hidden = true;
+    if (sharePreviewEl) {
+      sharePreviewEl.hidden = true;
+      sharePreviewEl.textContent = "";
+    }
+  }, 180);
+}
+
+function gatherContext() {
+  const submission = window.__lastSubmission || {};
+  const result = window.__lastResult || {};
+  const summary =
+    document.getElementById("response-summary")?.textContent.trim() ||
+    "Latest candidate feedback captured.";
+  const stage = submission.stage || "panel";
+  const index = Number(result.composite_index || 0.62);
+  const nss = Number(result.nss ?? 0.4);
+  const stageLabel = stageLabels[stage] || formatAspect(stage);
+  const aspects = Array.isArray(submission.aspects) && submission.aspects.length
+    ? submission.aspects
+    : ["communication", "feedback", "clarity"];
+  const deadlineLabel = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(Date.now() + 36 * 3600 * 1000);
+  return {
+    submission,
+    result,
+    summary,
+    stage,
+    stageLabel,
+    aspects,
+    index,
+    nss,
+    deadlineLabel,
+  };
+}
+
+function buildTasks(ctx) {
+  const priority = formatPriority(ctx.nss, ctx.index);
+  return ctx.aspects.slice(0, 3).map((aspect, idx) => {
+    const play = aspectPlaybook[aspect] || {
+      headline: `Improve ${formatAspect(aspect)}`,
+      action: `Run a coaching huddle focused on ${formatAspect(aspect)} and capture one measurable improvement.`,
+    };
+    const owner = roster[idx % roster.length];
+    return {
+      id: `task-${Date.now()}-${idx}`,
+      aspect,
+      headline: play.headline,
+      action: play.action,
+      owner,
+      priority: idx === 0 ? priority : idx === 1 ? "medium" : "low",
+    };
+  });
+}
+
+function renderChecklist(tasks, ctx) {
+  if (!checklistEl) return;
+  checklistEl.innerHTML = "";
+  tasks.forEach((task) => {
+    const item = document.createElement("label");
+    item.className = "checklist-item";
+    item.innerHTML = `
+      <input type="checkbox" data-task-id="${task.id}" checked />
+      <span>
+        <strong>${task.headline}</strong>
+        <em>${task.action}</em>
+        <small>Owner: ${task.owner.name} · ${task.owner.goal}</small>
+        <span class="chip chip-${task.priority}">${formatAspect(task.priority)} priority</span>
+      </span>
+    `;
+    checklistEl.appendChild(item);
+  });
+  if (summaryEl) {
+    summaryEl.textContent = `${tasks.length} coaching task${
+      tasks.length === 1 ? "" : "s"
+    } queued for ${ctx.stageLabel}.`;
+  }
+}
+
+function copySelectedTasks() {
+  if (!checklistEl) return;
+  const selectedIds = Array.from(
+    checklistEl.querySelectorAll('input[type="checkbox"]:checked'),
+  ).map((input) => input.dataset.taskId);
+  const tasks = currentTasks.filter((task) => selectedIds.includes(task.id));
+  if (!tasks.length) {
+    getToast()?.("Select at least one task to copy.", "warning");
+    return;
+  }
+  const payload = tasks
+    .map(
+      (task, idx) =>
+        `${idx + 1}. ${task.headline}\n   ${task.action}\n   Owner: ${task.owner.name} (${task.owner.goal})`,
+    )
+    .join("\n\n");
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(payload).then(
+      () => getToast()?.("Coaching tasks copied to clipboard.", "positive"),
+      () => getToast()?.("Clipboard copy unavailable in this browser.", "warning"),
+    );
+  } else {
+    getToast()?.("Clipboard access unavailable; select text manually.", "warning");
+  }
+}
+
+function handleShare(channel) {
+  if (!sharePreviewEl) return;
+  const template = shareTemplates[channel];
+  if (!template) return;
+  const preview = template(lastContext, currentTasks);
+  sharePreviewEl.hidden = false;
+  sharePreviewEl.textContent = preview;
+  sharePreviewEl.dataset.channel = channel;
+  const toastTone = channel === "email" || channel === "pdf" ? "positive" : "warning";
+  getToast()?.(`Preview ready for ${channel.toUpperCase()}.`, toastTone);
+}
+
+function highlightCell(aspect, stage) {
+  document
+    .querySelectorAll(".heatmap-cell.active")
+    .forEach((cell) => cell.classList.remove("active"));
+  const cell = document.querySelector(
+    `.heatmap-cell[data-aspect="${aspect}"][data-stage="${stage}"]`,
+  );
+  cell?.classList.add("active");
+}
+
+function extractEvidence(aspect) {
+  const submission = window.__lastSubmission || {};
+  const text = [submission.well, submission.better, submission.rant]
+    .filter(Boolean)
+    .join(" ");
+  if (!text) {
+    return [
+      "No transcript captured yet — once feedback is submitted, NSS will surface exact highlights.",
+    ];
+  }
+  const keywords = aspectKeywords[aspect] || [aspect];
+  const sentences = text.split(/(?<=[.!?])\s+/);
+  const matches = [];
+  sentences.forEach((sentence) => {
+    const lower = sentence.toLowerCase();
+    if (keywords.some((kw) => lower.includes(kw))) {
+      let highlighted = sentence;
+      keywords.forEach((kw) => {
+        const reg = new RegExp(`(${kw})`, "gi");
+        highlighted = highlighted.replace(reg, '<mark>$1</mark>');
+      });
+      matches.push(highlighted);
+    }
+  });
+  if (!matches.length) {
+    const first = sentences[0] || text;
+    return [first];
+  }
+  return matches.slice(0, 3);
+}
+
+function renderHeatmapDetail(aspect, stage) {
+  const detailEl = document.getElementById("heatmap-detail");
+  const titleEl = document.getElementById("detail-title");
+  const contentEl = document.getElementById("detail-content");
+  if (!detailEl || !titleEl || !contentEl) return;
+  highlightCell(aspect, stage);
+
+  const matrix = window.__lastResult?.heatmap || {};
+  const value = matrix?.[aspect]?.[stage];
+  const score = typeof value === "number" ? value : 0;
+  const ctx = gatherContext();
+  const evidence = extractEvidence(aspect);
+  const stageLabel = stageLabels[stage] || formatAspect(stage);
+  titleEl.textContent = `${formatAspect(aspect)} × ${stageLabel}`;
+  const tone = score > 0.15 ? "positive" : score < -0.15 ? "negative" : "neutral";
+  const formattedScore = `${score >= 0 ? "+" : ""}${score.toFixed(2)}`;
+  contentEl.innerHTML = `
+    <div class="score-pill score-${tone}">Sentiment ${formattedScore}</div>
+    <p class="mt-6">${aspectPlaybook[aspect]?.headline ||
+      `Focus on ${formatAspect(aspect)} to lift ${stageLabel}.`}</p>
+    <div class="mt-6"><strong>In their words:</strong></div>
+    <ul class="mt-025 insight-list">
+      ${evidence.map((line) => `<li>${line}</li>`).join("")}
+    </ul>
+    <div class="mt-6"><strong>Next coaching move:</strong></div>
+    <p>${aspectPlaybook[aspect]?.action ||
+      "Review transcripts and capture a coaching follow-up."}</p>
+    <div class="mt-8">
+      <button class="btn btn-primary" data-action="push-dashboard">Queue task for ${stageLabel}</button>
+    </div>
+  `;
+  contentEl
+    .querySelector('[data-action="push-dashboard"]')
+    ?.addEventListener("click", (event) => {
+      event.preventDefault();
+      pushToDashboard();
+    });
+  detailEl.classList.remove("hidden");
+  detailEl.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+function updateTaskHeader() {
+  const container = document.querySelector(".task-header");
+  if (!container) return;
+  const visible = Array.from(document.querySelectorAll(".task-item")).filter(
+    (item) => item.style.display !== "none",
+  );
+  container.textContent = `Active Tasks (${visible.length})`;
+}
+
+export function exportData(format = "json") {
+  ensureModalBound();
+  const previewEl = document.getElementById("export-preview");
+  const contentEl = document.getElementById("export-content");
+  if (!previewEl || !contentEl) return;
+  const ctx = gatherContext();
+  const payload = {
+    timestamp: new Date().toISOString(),
+    nss: ctx.nss,
+    composite_index: ctx.index,
+    stage: ctx.stage,
+    summary: ctx.summary,
+    coaching_cue:
+      document.getElementById("coaching-cue")?.textContent.trim() ||
+      "Coach interview team on timely follow-ups.",
+  };
+  let preview = "";
+  switch (format) {
+    case "json":
+      preview = JSON.stringify(payload, null, 2);
+      break;
+    case "csv":
+      preview = `timestamp,nss,index,stage,summary,coaching\n"${payload.timestamp}",${payload.nss.toFixed(
+        2,
+      )},${(payload.composite_index * 100).toFixed(0)},${payload.stage},"${payload.summary}","${payload.coaching_cue}"`;
+      break;
+    case "pdf":
+      preview = shareTemplates.pdf(ctx, buildTasks(ctx));
+      break;
+    case "summary":
+    default:
+      preview = `${ctx.summary}\n\nNSS: ${ctx.nss.toFixed(2)}\nComposite Index: ${(ctx.index * 100).toFixed(0)}\nCoaching: ${payload.coaching_cue}`;
+      break;
+  }
+  previewEl.hidden = false;
+  contentEl.textContent = preview;
+  getToast()?.(`Preview ready for ${format.toUpperCase()}.`, "positive");
+}
+
+export function showHeatmapDetail(aspect, stage) {
+  ensureModalBound();
+  renderHeatmapDetail(aspect, stage);
+}
+
+export function filterTasks() {
+  const stageFilter = document.getElementById("stage-filter")?.value || "";
+  const priorityFilter = document.getElementById("priority-filter")?.value || "";
+  const timeframeFilter = document.getElementById("timeframe-filter")?.value || "30d";
+  const maxAge = timeframeMinutes[timeframeFilter] || timeframeMinutes["30d"];
+  const now = Date.now();
+  const items = document.querySelectorAll(".task-item");
+  let visibleCount = 0;
+  items.forEach((item) => {
+    const stage = item.dataset.stage || "";
+    const priority = item.dataset.priority || "";
+    const created = Number(item.dataset.createdAt || 0);
+    const ageMinutes = created ? (now - created) / 60000 : Number(item.dataset.ageMinutes || 0);
+    const matchesStage = !stageFilter || stage === stageFilter;
+    const matchesPriority = !priorityFilter || priority === priorityFilter;
+    const matchesTimeframe = !maxAge || ageMinutes <= maxAge;
+    if (matchesStage && matchesPriority && matchesTimeframe) {
+      item.style.display = "block";
+      visibleCount += 1;
+    } else {
+      item.style.display = "none";
+    }
+  });
+  const header = document.querySelector(".task-header");
+  if (header) header.textContent = `Active Tasks (${visibleCount})`;
+}
+
+export function pushToDashboard() {
+  ensureModalBound();
+  if (!modalOverlay) return;
+  const ctx = gatherContext();
+  lastContext = ctx;
+  currentTasks = buildTasks(ctx);
+  renderChecklist(currentTasks, ctx);
+  openModal();
+  handleShare("email");
+  getToast()?.("Coaching plan staged in dashboard.", "positive");
+}
+
+export function pushToDashboardSilent(task) {
+  currentTasks = buildTasks(task || gatherContext());
+}
+
+export function showHeatmapDetailFromCell(aspect, stage) {
+  showHeatmapDetail(aspect, stage);
+}
+
+// Initialize filters on load
+if (document.readyState === "complete") {
+  filterTasks();
+} else {
+  window.addEventListener("load", () => filterTasks());
+}
+
+export function updateRosterHighlight() {
+  const rosterEl = document.getElementById("interviewer-roster");
+  if (!rosterEl) return;
+  rosterEl.classList.add("pulse");
+  setTimeout(() => rosterEl.classList.remove("pulse"), 1200);
+}
+
+export default {
+  exportData,
+  showHeatmapDetail,
+  filterTasks,
+  pushToDashboard,
+};

--- a/dist/js/invite.js
+++ b/dist/js/invite.js
@@ -1,21 +1,172 @@
-// Survey invitation and modal functionality
-
 const inlineOpenInvite =
   typeof window !== "undefined" && typeof window.openInvite === "function"
     ? window.openInvite
     : null;
 
+const toast = () => window.__cxToast || window.showToast || null;
+
+const stageLabels = {
+  applied: "Applied",
+  recruiter: "Recruiter Screen",
+  hiring_manager: "Hiring Manager",
+  panel: "Panel Interview",
+  assignment: "Take-home",
+  offer: "Offer",
+  rejected: "Closure",
+};
+
+function formatAspect(value = "") {
+  return value
+    .replace(/[_-]/g, " ")
+    .replace(/\b\w/g, (m) => m.toUpperCase())
+    .trim();
+}
+
+function derivePriority(index = 0.6, nss = 0.3) {
+  if (nss < 0 || index < 0.5) return "high";
+  if (nss < 0.35 || index < 0.65) return "medium";
+  return "low";
+}
+
+function ensureTaskHeader() {
+  const header = document.querySelector(".task-header");
+  if (!header) return;
+  const visible = Array.from(document.querySelectorAll(".task-item"))
+    .filter((item) => item.style.display !== "none")
+    .length;
+  header.textContent = `Active Tasks (${visible})`;
+}
+
+function createTaskCard({
+  stage,
+  aspects,
+  index,
+  priority,
+  createdAt,
+  nss,
+  cue,
+}) {
+  const container = document.getElementById("task-list");
+  if (!container) return null;
+  const card = document.createElement("div");
+  card.className = "task-item";
+  card.dataset.stage = stage;
+  card.dataset.priority = priority;
+  card.dataset.createdAt = createdAt;
+  card.dataset.ageMinutes = Math.max(
+    0,
+    Math.round((Date.now() - createdAt) / 60000),
+  );
+  const stageLabel = stageLabels[stage] || formatAspect(stage);
+  const aspectTags = (aspects || [])
+    .map((a) => `<span class="tag">${formatAspect(a)}</span>`)
+    .join(" ");
+  const priorityLabel = priority.charAt(0).toUpperCase() + priority.slice(1);
+  const diffMinutes = Math.max(1, Math.round((Date.now() - createdAt) / 60000));
+  const relFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  const ageLabel =
+    diffMinutes < 60
+      ? relFormatter.format(-diffMinutes, "minute")
+      : relFormatter.format(-Math.round(diffMinutes / 60), "hour");
+  card.innerHTML = `
+    <div class="task-meta">
+      <div>
+        <span class="task-priority priority-${priority}">${priorityLabel}</span>
+        <span class="muted ml-1">${stageLabel} • ${ageLabel}</span>
+      </div>
+      <div class="muted small">NSS: ${nss >= 0 ? "+" : ""}${nss.toFixed(2)}</div>
+    </div>
+    <div class="task-coaching">${cue}</div>
+    <div class="task-details">Aspects: ${aspectTags || "–"} • Index: ${(index * 100).toFixed(
+    0,
+  )}</div>
+  `;
+  container.prepend(card);
+  return card;
+}
+
+function appendTaskRow({ stage, aspects, index, priority, createdAt, nss, cue }) {
+  const tableBody = document.getElementById("task-rows");
+  if (!tableBody) return;
+  const row = document.createElement("tr");
+  const ts = new Date(createdAt);
+  row.innerHTML = `
+    <td>${ts.toLocaleString()}</td>
+    <td>${stageLabels[stage] || formatAspect(stage)}</td>
+    <td>${(aspects || [])
+      .map((aspect) => `<span class="tag">${formatAspect(aspect)}</span>`)
+      .join(" ")}</td>
+    <td><span class="priority-${priority}">${(index * 100).toFixed(0)}</span></td>
+  `;
+  tableBody.prepend(row);
+}
+
 export function openInvite(candidateToken = "", nudgeRound = 0) {
   if (typeof inlineOpenInvite === "function") {
     return inlineOpenInvite(candidateToken, nudgeRound);
   }
+  return null;
 }
 
-export function pushTaskRow(task) {
-  console.log('pushTaskRow:', task);
+export function pushTaskRow(task = {}) {
+  const submission = window.__lastSubmission || {};
+  const result = window.__lastResult || {};
+  const stage = task.stage || submission.stage || "panel";
+  const aspects = task.aspects && task.aspects.length ? task.aspects : submission.aspects || [];
+  const index =
+    typeof task.index === "number"
+      ? task.index
+      : typeof result.composite_index === "number"
+        ? result.composite_index
+        : 0.62;
+  const nss =
+    typeof task.nss === "number"
+      ? task.nss
+      : typeof result.nss === "number"
+        ? result.nss
+        : 0.32;
+  const cue =
+    task.cue ||
+    document.getElementById("coaching-cue")?.textContent ||
+    "Confirm follow-up SLAs and share the interview outline.";
+  const priority = task.priority || derivePriority(index, nss);
+  const createdAt = task.createdAt || Date.now();
+
+  createTaskCard({ stage, aspects, index, priority, createdAt, nss, cue });
+  appendTaskRow({ stage, aspects, index, priority, createdAt, nss, cue });
+  ensureTaskHeader();
+  window.filterTasks?.();
+  const notify = toast();
+  notify?.("Task queued for the hiring squad.", priority === "high" ? "warning" : "positive");
 }
 
-export function showATSWebhook() {
-  const panel = document.getElementById('ats-panel');
+export function showATSWebhook(stage, role, token) {
+  let debugMode = false;
+  try {
+    debugMode = new URL(location.href).searchParams.get("debug") === "1";
+  } catch (_) {
+    debugMode = false;
+  }
+  if (!debugMode) return;
+  const payload = {
+    event: "candidate_feedback_invite",
+    stage: stage || "panel",
+    role_family: role || "engineering",
+    candidate_token:
+      token ||
+      window.CANDIDATE_TOKEN ||
+      "anon_" + Math.random().toString(36).slice(2, 7),
+    sent_at: new Date().toISOString(),
+    source: new URL(location.href).searchParams.get("src") || null,
+  };
+  const panel = document.getElementById("ats-panel");
+  const json = document.getElementById("ats-json");
+  const stageEl = document.getElementById("ats-stage");
+  const roleEl = document.getElementById("ats-role");
+  const tokenEl = document.getElementById("ats-token");
+  if (stageEl) stageEl.textContent = payload.stage;
+  if (roleEl) roleEl.textContent = payload.role_family;
+  if (tokenEl) tokenEl.textContent = payload.candidate_token;
+  if (json) json.textContent = JSON.stringify(payload, null, 2);
   if (panel) panel.hidden = false;
 }

--- a/dist/js/utils.js
+++ b/dist/js/utils.js
@@ -29,3 +29,49 @@ export function debounce(func, wait) {
     timeout = setTimeout(later, wait);
   };
 }
+
+export function animateNumber(
+  element,
+  { from = 0, to = 0, duration = 800, decimals = 0, prefix = "", suffix = "" } = {}
+) {
+  if (!element) return;
+  const start = Number(from);
+  const end = Number(to);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    element.textContent = `${prefix}${end.toFixed?.(decimals) ?? end}${suffix}`;
+    return;
+  }
+  const delta = end - start;
+  const startTime = performance.now();
+  const easeOut = (t) => 1 - Math.pow(1 - t, 3);
+
+  function tick(now) {
+    const elapsed = Math.min(1, (now - startTime) / duration);
+    const eased = easeOut(elapsed);
+    const value = start + delta * eased;
+    element.textContent = `${prefix}${value.toFixed(decimals)}${suffix}`;
+    if (elapsed < 1) requestAnimationFrame(tick);
+  }
+
+  requestAnimationFrame(tick);
+}
+
+export async function typewriter(element, text, { delay = 22 } = {}) {
+  if (!element) return;
+  element.textContent = "";
+  for (const char of text.split("")) {
+    element.textContent += char;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+}
+
+export function seededRandom(seed = "", key = "") {
+  const str = `${seed}:${key}`;
+  let h = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    h = Math.imul(31, h) + str.charCodeAt(i);
+  }
+  const normalized = ((h >>> 0) % 10000) / 10000;
+  return normalized;
+}

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -1,8 +1,36 @@
 /* Extracted styles from inline index.html for maintainability */
-:root { --primary:#667eea; --primary-dark:#5a6fd8; --cxi-amber:#667eea; --cxi-navy:#333333; --slate:#e9ecef; --success:#16a34a; --warning:#f59e0b; --risk:#f43f5e; --bg:#ffffff; --card:#ffffff; --text:#333333; --muted:rgba(0,0,0,0.6); --radius:12px; --shadow:0 10px 30px rgba(0,0,0,0.2); --gradient-app:linear-gradient(135deg,#667eea 0%,#764ba2 100%); --gradient-positive:linear-gradient(90deg,#22c55e,#84cc16); }
+:root {
+  --primary: #7c5cff;
+  --primary-dark: #6040f8;
+  --primary-soft: rgba(124, 92, 255, 0.18);
+  --cxi-amber: #f7b733;
+  --cxi-navy: #101631;
+  --slate: rgba(148, 163, 184, 0.28);
+  --success: #4ade80;
+  --warning: #facc15;
+  --risk: #fb7185;
+  --bg: #0c1224;
+  --card: rgba(14, 21, 41, 0.92);
+  --card-glass: rgba(20, 27, 51, 0.78);
+  --text: #f8fbff;
+  --muted: rgba(226, 232, 255, 0.72);
+  --radius: 16px;
+  --shadow: 0 24px 54px rgba(4, 11, 32, 0.55);
+  --shadow-soft: 0 14px 36px rgba(20, 28, 56, 0.55);
+  --gradient-app: radial-gradient(140% 120% at 10% 0%, #24153d 0%, #0d1630 38%, #050914 100%);
+  --gradient-results: linear-gradient(135deg, #3425a0 0%, #512d8d 38%, #12192f 100%);
+  --gradient-positive: linear-gradient(100deg, #10b981 0%, #22d3ee 100%);
+  --gradient-risk: linear-gradient(100deg, #fb7185 0%, #f97316 100%);
+  --heat-positive: rgba(34, 197, 94, 0.18);
+  --heat-negative: rgba(248, 113, 113, 0.22);
+  --heat-neutral: rgba(234, 179, 8, 0.18);
+  --font-display: "Inter", "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --blur-xl: blur(28px);
+}
 *{margin:0;padding:0;box-sizing:border-box;}
-body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--gradient-app);color:var(--text);overflow:hidden;}
-@media (prefers-reduced-motion:reduce){body{background:#667eea;}}
+body{font-family:var(--font-display);background:var(--gradient-app);color:var(--text);min-height:100vh;overflow-x:hidden;overflow-y:auto;transition:background .6s ease;}
+@media (prefers-reduced-motion:reduce){body{background:#101631;}}
 #hud-toggle-btn{position:fixed;top:8px;left:8px;z-index:9998;background:rgba(0,0,0,0.55);color:#fff;border:1px solid rgba(255,255,255,0.25);padding:6px 10px;font:12px system-ui,sans-serif;border-radius:6px;cursor:pointer;-webkit-backdrop-filter:blur(4px);backdrop-filter:blur(4px);transition:background .2s;}#hud-toggle-btn:hover{background:rgba(0,0,0,0.7);}
 .skip-link{position:absolute;left:-999px;top:8px;background:#111;color:#fff;padding:8px 12px;border-radius:6px;z-index:10000;}.skip-link:focus{left:8px;outline:2px solid #fff;}
 .invite-sub{margin:6px 0 10px;}
@@ -13,21 +41,24 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;b
 .export-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;}
 .export-pre{background:var(--bg);padding:1rem;border-radius:6px;overflow:auto;max-height:400px;}
 .countdown{font-weight:700;color:var(--primary);} .winmeter{background:#0a1b34;border:1px solid #1d3153;border-radius:10px;padding:10px;margin-top:10px;} .winmeter .bar{height:8px;background:#132440;border-radius:6px;overflow:hidden;margin-top:6px;} .winmeter .fill{height:100%;width:0%;background:var(--gradient-positive);transition:width .5s ease;}
-.interview-container{height:100vh;display:flex;flex-direction:column;background:transparent;}
-.cxi-meeting{background:#0b1220;border:1px solid #1c2334;border-radius:14px;overflow:hidden;position:relative;}
-.call-instructions{position:absolute;top:16px;left:16px;width:min(260px,92%);padding:16px 18px;border-radius:14px;border:1px solid rgba(148,163,184,0.35);background:rgba(15,23,42,0.9);color:#e6efff;box-shadow:0 18px 36px rgba(2,6,23,0.55);backdrop-filter:blur(6px);z-index:20;}
-.call-instructions .eyebrow{display:block;font-size:.68rem;letter-spacing:.18em;text-transform:uppercase;font-weight:700;margin-bottom:.35rem;color:#60a5fa;}
-.call-instructions h2{font-size:1rem;line-height:1.35;margin-bottom:.75rem;color:#f8fafc;}
-.call-instructions p{font-size:.84rem;line-height:1.4;color:rgba(226,232,255,0.92);margin-bottom:.5rem;}
-.call-instructions ul{margin:0;padding-left:1.1rem;display:grid;gap:.45rem;font-size:.78rem;color:rgba(226,232,255,0.82);text-align:left;}
+.interview-container{min-height:calc(100vh - 32px);display:flex;justify-content:center;align-items:center;padding:clamp(16px,3vw,48px);background:transparent;}
+.cxi-meeting{background:var(--card-glass);border:1px solid rgba(99,102,241,.28);border-radius:24px;overflow:hidden;position:relative;width:min(1120px,96vw);box-shadow:var(--shadow);backdrop-filter:blur(24px);}
+.call-instructions{position:absolute;top:20px;left:20px;width:min(300px,90%);padding:18px 20px 22px;border-radius:18px;border:1px solid rgba(148,163,184,.35);background:linear-gradient(145deg,rgba(14,21,41,.96),rgba(40,30,72,.88));color:#e6efff;box-shadow:0 18px 42px rgba(12,18,36,.75);backdrop-filter:blur(20px);z-index:24;transition:opacity .45s ease,transform .45s ease;}
+.call-instructions[data-hidden="true"]{opacity:0;transform:translateY(-12px) scale(.96);pointer-events:none;}
+.call-instructions[data-state="fading"]{opacity:.1;}
+.call-instructions .eyebrow{display:flex;align-items:center;gap:6px;font-size:.68rem;letter-spacing:.18em;text-transform:uppercase;font-weight:700;margin-bottom:.4rem;color:#7dd3fc;}
+.call-instructions .eyebrow::before{content:"";width:28px;height:1px;background:linear-gradient(90deg,transparent,rgba(125,211,252,.6));}
+.call-instructions h2{font-size:1.12rem;line-height:1.4;margin-bottom:.75rem;color:#f8fafc;}
+.call-instructions p{font-size:.88rem;line-height:1.48;color:rgba(226,232,255,.92);margin-bottom:.5rem;}
+.call-instructions ul{margin:0;padding-left:1.1rem;display:grid;gap:.45rem;font-size:.8rem;color:rgba(226,232,255,.82);text-align:left;}
 .call-instructions li strong{color:#facc15;font-weight:700;}
 .call-instructions footer{margin-top:.75rem;font-size:.72rem;color:rgba(148,163,184,0.9);}
-.cxi-topbar{display:flex;justify-content:space-between;align-items:center;padding:10px 12px;background:#0f172a;color:#dbe3f8;border-bottom:1px solid #1f2840;}
+.cxi-topbar{display:flex;justify-content:space-between;align-items:center;padding:14px 18px;background:rgba(12,17,38,.88);color:#dbe3f8;border-bottom:1px solid rgba(148,163,184,.16);}
 .cxi-topbar .left,.cxi-topbar .right{display:flex;align-items:center;gap:8px;}
 .cxi-topbar .dot{width:8px;height:8px;border-radius:999px;display:inline-block;} .cxi-topbar .dot.live{background:#f43f5e;box-shadow:0 0 0 6px rgba(244,63,94,0.15);} .cxi-topbar .chip{font-size:.78rem;padding:4px 8px;border-radius:999px;background:#0b1329;border:1px solid #243356;color:#aac0ee;} .cxi-topbar .topic{color:#b9c7ea;} .cxi-topbar .sep{color:#5b6c93;}
-.cxi-gallery{display:grid;grid-template-columns:repeat(2,1fr);gap:10px;padding:12px;background:#0b1220;} .cxi-gallery .tile{background:radial-gradient(120% 120% at 0% 0%,#19233c,#0e1528 70%);border:1px solid #1b2440;border-radius:12px;aspect-ratio:16/9;position:relative;} .cxi-gallery .badge{position:absolute;left:8px;bottom:8px;background:rgba(0,0,0,0.45);color:#e6edff;padding:4px 8px;border-radius:8px;font-size:.8rem;border:1px solid rgba(255,255,255,0.15);}
-.cxi-toolbar{display:flex;align-items:center;gap:8px;padding:10px;background:#0f172a;border-top:1px solid #1f2840;} .cxi-toolbar .ctrl{background:#101a33;color:#dbe3f8;border:1px solid #243356;padding:8px 12px;border-radius:10px;cursor:pointer;position:relative;} .cxi-toolbar .ctrl::after{content:"";position:absolute;inset:-4px;border-radius:12px;border:2px solid transparent;pointer-events:none;transition:border-color .12s ease,box-shadow .12s ease;} .cxi-toolbar .ctrl:hover{background:#132040;} .cxi-toolbar .ctrl:hover::after{border-color:rgba(96,165,250,0.35);box-shadow:0 0 0 2px rgba(37,99,235,0.2);} .cxi-toolbar .ctrl:focus-visible::after{border-color:rgba(96,165,250,0.75);box-shadow:0 0 0 3px rgba(37,99,235,0.35);} .cxi-toolbar .ctrl.leave{background:#2a0f14;border-color:#5a1b23;color:#fecaca;font-weight:700;} .cxi-toolbar .ctrl.leave:hover{background:#3a1218;box-shadow:0 12px 22px rgba(127,29,29,0.4);} .cxi-toolbar .ctrl.leave:hover::after,.cxi-toolbar .ctrl.leave:focus-visible::after{border-color:rgba(248,113,113,0.55);box-shadow:0 0 0 3px rgba(248,113,113,0.32);}
-@media (max-width:680px){.call-instructions{position:fixed;top:auto;bottom:18px;left:50%;transform:translateX(-50%);width:min(320px,94vw);padding:14px 16px;}}
+.cxi-gallery{display:grid;grid-template-columns:repeat(2,1fr);gap:12px;padding:18px;background:rgba(9,14,30,.82);} .cxi-gallery .tile{background:radial-gradient(140% 140% at 0% 0%,rgba(32,45,92,.86),rgba(11,18,40,.95) 70%);border:1px solid rgba(96,109,181,.25);border-radius:16px;aspect-ratio:16/9;position:relative;overflow:hidden;} .cxi-gallery .badge{position:absolute;left:12px;bottom:12px;background:rgba(12,18,38,.72);color:#e6edff;padding:4px 10px;border-radius:999px;font-size:.82rem;border:1px solid rgba(255,255,255,.18);}
+.cxi-toolbar{display:flex;align-items:center;gap:10px;padding:14px 18px;background:rgba(12,18,38,.92);border-top:1px solid rgba(148,163,184,.16);} .cxi-toolbar .ctrl{background:rgba(13,20,44,.92);color:#dbe3f8;border:1px solid rgba(80,102,176,.45);padding:10px 14px;border-radius:14px;cursor:pointer;position:relative;font-weight:600;font-size:.92rem;box-shadow:inset 0 0 0 1px rgba(90,113,204,.12);} .cxi-toolbar .ctrl::after{content:"";position:absolute;inset:-4px;border-radius:16px;border:2px solid transparent;pointer-events:none;transition:border-color .18s ease,box-shadow .18s ease;} .cxi-toolbar .ctrl:hover{background:rgba(17,26,56,.92);} .cxi-toolbar .ctrl:hover::after{border-color:rgba(96,165,250,.4);box-shadow:0 0 0 2px rgba(59,130,246,.18);} .cxi-toolbar .ctrl:focus-visible::after{border-color:rgba(148,197,255,.8);box-shadow:0 0 0 3px rgba(96,165,250,.35);} .cxi-toolbar .ctrl.leave{background:linear-gradient(120deg,rgba(248,113,113,.9),rgba(244,63,94,.92));border-color:rgba(248,113,113,.8);color:#fff4f4;font-weight:700;box-shadow:0 14px 28px rgba(248,113,113,.35);} .cxi-toolbar .ctrl.leave:hover{background:linear-gradient(120deg,rgba(239,68,68,.95),rgba(220,38,38,.92));} .cxi-toolbar .ctrl.leave:hover::after,.cxi-toolbar .ctrl.leave:focus-visible::after{border-color:rgba(248,180,180,.75);box-shadow:0 0 0 3px rgba(248,113,113,.32);}
+@media (max-width:680px){.interview-container{padding:12px;}.cxi-meeting{border-radius:18px;}.call-instructions{position:fixed;top:auto;bottom:18px;left:50%;transform:translateX(-50%);width:min(320px,94vw);padding:16px 18px 20px;}}
 
 /* Button hover/press affordance */
 .btn, .cxi-btn, .rating-btn, .aspect-btn, .ctrl { transition: transform .08s ease, box-shadow .12s ease, background-color .12s ease, border-color .12s ease; }
@@ -39,3 +70,177 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;b
 #results-view .results-card { padding: 1rem; }
 #results-view .results-grid { gap: 1rem; }
 #results-view .score-value { font-size: 2.4rem; }
+body[data-stage="results"]{background:var(--gradient-results);}
+.call-instructions button.dismiss{position:absolute;top:10px;right:10px;width:26px;height:26px;border-radius:999px;border:1px solid rgba(125,211,252,.4);background:rgba(9,14,30,.6);color:#cbd5f5;font-size:.8rem;cursor:pointer;transition:transform .25s ease,border-color .25s ease;}
+.call-instructions button.dismiss:hover{transform:scale(1.08);border-color:rgba(125,211,252,.8);}
+.cxi-gallery .tile::after{content:"";position:absolute;inset:0;background:linear-gradient(120deg,rgba(124,92,255,.18),transparent 55%);opacity:0;transition:opacity .4s ease;}
+.cxi-gallery .tile:hover::after{opacity:1;}
+.btn,.cxi-btn,.rating-btn,.aspect-btn,.ctrl{transition:transform .12s ease,box-shadow .16s ease,background-color .16s ease,border-color .16s ease;}
+.btn:hover,.cxi-btn:hover,.rating-btn:hover,.aspect-btn:hover,.ctrl:hover{transform:translateY(-1px);}
+.score-reveal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:clamp(24px,6vw,48px);background:rgba(5,7,20,.8);backdrop-filter:blur(26px);z-index:10020;opacity:0;pointer-events:none;transition:opacity .45s ease;}
+.score-reveal.is-visible{opacity:1;pointer-events:auto;}
+.score-reveal__panel{position:relative;width:min(760px,94vw);padding:clamp(28px,4vw,42px);border-radius:26px;border:1px solid rgba(124,92,255,.35);background:radial-gradient(circle at 0% 0%,rgba(124,92,255,.18),transparent 55%),linear-gradient(135deg,rgba(15,23,42,.95),rgba(8,13,32,.92));box-shadow:0 26px 64px rgba(3,9,28,.68);overflow:hidden;}
+.score-reveal__panel::before{content:"";position:absolute;inset:-40%;background:conic-gradient(from 120deg,rgba(124,92,255,.15),rgba(59,130,246,.1),rgba(34,197,94,.16),rgba(124,92,255,.12));opacity:0;animation:hero-flash 1.8s ease forwards;pointer-events:none;}
+.score-reveal__close{position:absolute;top:16px;right:16px;width:34px;height:34px;border-radius:999px;border:1px solid rgba(148,163,184,.38);background:rgba(10,16,32,.72);color:#cbd5f5;font-size:1.2rem;cursor:pointer;transition:transform .2s ease, border-color .2s ease;}
+.score-reveal__close:hover{transform:scale(1.08);border-color:rgba(148,197,255,.85);}
+.score-reveal__eyebrow{display:inline-flex;align-items:center;gap:8px;text-transform:uppercase;letter-spacing:.16em;font-size:.72rem;color:rgba(165,180,252,.9);margin-bottom:.5rem;}
+.score-reveal__eyebrow::before{content:"";width:32px;height:1px;background:linear-gradient(90deg,rgba(148,197,255,.65),transparent);}
+.score-reveal__headline{font-size:clamp(1.6rem,3.4vw,2.2rem);color:#f8fbff;margin-bottom:1.2rem;}
+.score-reveal__grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:14px;margin-bottom:1.4rem;}
+.score-reveal__metric{background:rgba(12,18,36,.82);border:1px solid rgba(148,163,184,.22);border-radius:18px;padding:14px 18px;box-shadow:0 18px 34px rgba(8,13,32,.45);text-align:center;}
+.score-reveal__metric .label{display:block;font-size:.72rem;text-transform:uppercase;letter-spacing:.12em;color:rgba(191,219,254,.74);margin-bottom:.4rem;}
+.score-reveal__metric .value{font-size:1.9rem;font-weight:700;color:#f8fbff;}
+.score-reveal__metric .value[data-reveal-nss]{font-variant-numeric:tabular-nums;font-size:1.8rem;}
+.score-reveal__summary{font-size:1rem;line-height:1.6;color:rgba(226,232,255,.88);background:rgba(9,14,30,.68);border-radius:16px;padding:16px 18px;border:1px solid rgba(148,163,184,.18);box-shadow:inset 0 0 0 1px rgba(96,165,250,.14);transition:box-shadow .3s ease;}
+.score-reveal__summary.is-highlighted{box-shadow:0 0 0 1px rgba(59,130,246,.45),0 0 30px rgba(59,130,246,.28);}
+.score-reveal__stage{display:flex;align-items:center;gap:12px;margin-top:1.2rem;font-size:.88rem;color:rgba(165,180,252,.85);text-transform:uppercase;letter-spacing:.12em;}
+.score-reveal__stage .band-pill{padding:.35rem .75rem;border-radius:999px;background:rgba(34,197,94,.22);border:1px solid rgba(34,197,94,.32);color:#bbf7d0;font-weight:700;}
+.score-reveal__aspects{display:flex;flex-wrap:wrap;gap:10px;margin-top:1.4rem;}
+.score-reveal__aspects span{padding:.45rem .85rem;border-radius:999px;border:1px solid rgba(148,163,184,.24);background:rgba(14,21,41,.8);color:#e0e7ff;font-size:.82rem;font-weight:600;box-shadow:0 10px 24px rgba(8,13,32,.38);}
+.score-reveal__sentence{margin-top:1.4rem;font-family:var(--font-mono);font-size:.95rem;line-height:1.7;background:rgba(8,13,32,.82);border-radius:16px;padding:16px 18px;border:1px solid rgba(148,163,184,.2);color:rgba(203,213,225,.85);min-height:82px;}
+.score-reveal__sentence mark{background:rgba(124,92,255,.35);color:#f8fafc;padding:2px 4px;border-radius:6px;transition:background .3s ease,color .3s ease;}
+.score-reveal__actions{margin-top:1.6rem;display:flex;flex-wrap:wrap;gap:12px;justify-content:flex-end;}
+.score-reveal__actions .btn{min-width:160px;}
+@media (max-width:640px){
+  .score-reveal__grid{grid-template-columns:repeat(2,minmax(120px,1fr));}
+  .score-reveal__actions{justify-content:center;}
+}
+.btn:active,.cxi-btn:active,.rating-btn:active,.aspect-btn:active,.ctrl:active,
+.btn.pressed,.cxi-btn.pressed,.rating-btn.pressed,.aspect-btn.pressed,.ctrl.pressed{transform:translateY(0);box-shadow:inset 0 2px 0 rgba(0,0,0,.12);}
+textarea,
+input[type="text"],
+input[type="email"],
+select{background:
+    radial-gradient(140% 120% at 0% 0%,rgba(124,92,255,.16),transparent 62%),
+    linear-gradient(135deg,rgba(17,24,39,.96),rgba(10,18,36,.92));
+  border:1px solid rgba(148,163,184,.34);
+  border-radius:16px;
+  padding:.95rem 1.1rem;
+  color:#f8fbff;
+  font-family:var(--font-display);
+  box-shadow:0 16px 36px rgba(9,15,30,.46),inset 0 0 0 1px rgba(99,102,241,.18);
+  transition:border-color .24s ease,box-shadow .24s ease,background-position .38s ease;
+  background-size:140% 140%,100% 100%;
+}
+textarea:hover,
+input[type="text"]:hover,
+input[type="email"]:hover,
+select:hover{background-position:10% 12%,0 0;}
+textarea:focus,
+input[type="text"]:focus,
+input[type="email"]:focus,
+select:focus{outline:none;border-color:rgba(124,92,255,.88);box-shadow:0 0 0 3px rgba(124,92,255,.28),0 22px 44px rgba(11,20,44,.55);}
+textarea{min-height:120px;max-height:240px;overflow-y:auto;line-height:1.55;resize:vertical;}
+textarea::placeholder,
+input[type="text"]::placeholder,
+input[type="email"]::placeholder{color:rgba(226,232,255,.65);letter-spacing:.02em;}
+textarea::-webkit-scrollbar,.transcript-playback::-webkit-scrollbar,#export-preview pre::-webkit-scrollbar{width:8px;height:8px;}
+textarea::-webkit-scrollbar-thumb,.transcript-playback::-webkit-scrollbar-thumb,#export-preview pre::-webkit-scrollbar-thumb{background:rgba(124,92,255,.38);border-radius:8px;}
+.results-container{min-height:100vh;padding:clamp(40px,6vw,72px) clamp(24px,6vw,72px) 96px;display:flex;flex-direction:column;gap:24px;align-items:center;justify-content:flex-start;position:relative;}
+.results-header{text-align:center;max-width:720px;}
+.results-header h1{font-size:clamp(2.1rem,3vw,2.8rem);color:#f8fbff;margin-bottom:.35rem;text-shadow:0 18px 42px rgba(5,9,24,.55);}
+.results-header p{color:rgba(226,232,255,.76);font-size:1rem;}
+.navigation-tabs{background:rgba(12,18,38,.62);border-radius:999px;padding:6px;border:1px solid rgba(148,163,184,.2);box-shadow:0 18px 40px rgba(6,11,28,.45);}
+.navigation-tabs div{display:flex;gap:8px;justify-content:center;flex-wrap:wrap;}
+.navigation-tabs button{border-radius:999px;padding:10px 22px;font-weight:600;color:rgba(226,232,255,.66);background:transparent;}
+.navigation-tabs button.active{background:linear-gradient(120deg,rgba(124,92,255,.92),rgba(98,224,255,.82));color:#0a1026;box-shadow:0 12px 24px rgba(124,92,255,.4);}
+.results-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:clamp(18px,3vw,32px);width:min(1200px,100%);}
+.results-card{background:var(--card);border-radius:var(--radius);padding:clamp(20px,3vw,28px);border:1px solid rgba(148,163,184,.18);box-shadow:var(--shadow-soft);backdrop-filter:blur(24px);position:relative;overflow:hidden;}
+.results-card.highlight-card{background:linear-gradient(140deg,rgba(124,92,255,.32),rgba(17,24,54,.88));}
+.results-card.highlight-card::after{content:"";position:absolute;inset:-40% -10% auto -10%;height:70%;background:radial-gradient(circle at 30% 40%,rgba(98,224,255,.35),transparent 65%);opacity:.8;pointer-events:none;}
+.score-display{text-align:center;margin-bottom:1.4rem;position:relative;}
+.score-value{font-size:clamp(2.4rem,4vw,3.4rem);font-weight:800;margin:1rem 0 .35rem;color:#fff;text-shadow:0 14px 32px rgba(15,23,42,.6);}
+.score-label{color:rgba(226,232,255,.65);font-size:.78rem;text-transform:uppercase;letter-spacing:.12em;}
+.band-indicator{display:inline-flex;align-items:center;gap:6px;padding:.5rem 1.1rem;border-radius:999px;font-weight:600;font-size:.88rem;}
+.band-success{background:var(--gradient-positive);color:#052e16;}
+.band-caution{background:linear-gradient(120deg,rgba(250,204,21,.82),rgba(253,224,71,.66));color:#3b2602;}
+.band-risk{background:var(--gradient-risk);color:#fff5f4;}
+.results-hero{display:grid;grid-template-columns:minmax(220px,1fr) 1.2fr;gap:clamp(18px,3vw,32px);align-items:center;}
+.score-orb{position:relative;width:clamp(220px,30vw,280px);aspect-ratio:1;border-radius:50%;background:radial-gradient(circle at 30% 25%,rgba(255,255,255,.22),transparent 68%),radial-gradient(circle at 70% 80%,rgba(124,92,255,.85),rgba(71,63,197,.82));display:flex;align-items:center;justify-content:center;flex-direction:column;box-shadow:0 24px 54px rgba(79,70,229,.45);overflow:hidden;margin:0 auto;}
+.score-orb::after{content:"";position:absolute;inset:12%;border-radius:50%;border:1px solid rgba(255,255,255,.2);box-shadow:inset 0 0 40px rgba(255,255,255,.16);pointer-events:none;}
+.orb-value{font-size:clamp(2.6rem,5vw,3.6rem);font-weight:800;color:#fff;}
+.orb-label{font-size:.82rem;letter-spacing:.18em;text-transform:uppercase;margin-top:.75rem;color:rgba(244,244,255,.72);}
+.orb-band{margin-top:.4rem;font-size:.88rem;color:rgba(255,255,255,.9);}
+.orb-band span{padding:.2rem .65rem;border-radius:999px;background:rgba(15,23,42,.45);border:1px solid rgba(255,255,255,.2);}
+.hero-metric-grid{display:grid;gap:12px;}
+.metric-tile{background:rgba(13,21,44,.82);padding:14px 18px;border-radius:14px;border:1px solid rgba(148,163,184,.2);display:flex;justify-content:space-between;align-items:center;gap:12px;}
+.metric-tile .metric-label{font-size:.82rem;text-transform:uppercase;letter-spacing:.08em;color:rgba(226,232,255,.68);}
+.metric-tile .metric-value{font-size:1.6rem;font-weight:700;color:#f8fbff;}
+.transcript-playback{margin-top:1.4rem;padding:16px 18px;border-radius:14px;border:1px solid rgba(148,163,184,.16);background:rgba(6,10,24,.65);font-family:var(--font-mono);font-size:.92rem;max-height:160px;overflow-y:auto;line-height:1.6;box-shadow:inset 0 0 0 1px rgba(71,85,105,.16);}
+.transcript-playback span{display:inline;padding:.05rem .25rem;border-radius:6px;transition:background .35s ease,color .35s ease;}
+.transcript-playback span.active{background:rgba(56,189,248,.28);color:#f8fafc;box-shadow:0 0 0 2px rgba(56,189,248,.12);}
+.heatmap-container{width:min(1120px,100%);display:grid;gap:18px;}
+.heatmap-grid{display:grid;grid-template-columns:140px repeat(7,1fr);gap:10px;align-items:stretch;}
+.heatmap-row-label{display:flex;align-items:center;justify-content:flex-start;padding:12px 14px;background:rgba(12,18,36,.72);border-radius:12px;border:1px solid rgba(148,163,184,.18);font-weight:600;}
+.heatmap-cell{border-radius:12px;padding:12px 10px;font-weight:600;text-align:center;cursor:pointer;position:relative;overflow:hidden;border:1px solid transparent;transition:transform .18s ease,box-shadow .18s ease,border-color .18s ease;}
+.heatmap-cell.active{transform:translateY(-2px);border-color:rgba(59,130,246,.6);box-shadow:0 18px 32px rgba(14,23,42,.55);}
+.heatmap-cell::after{content:attr(data-label);position:absolute;inset:auto 6px 8px;font-size:.68rem;text-transform:uppercase;letter-spacing:.12em;color:rgba(15,23,42,.66);font-weight:700;}
+.heatmap-cell.heatmap-positive{background:var(--heat-positive);color:#22c55e;border-color:rgba(34,197,94,.3);}
+.heatmap-cell.heatmap-negative{background:var(--heat-negative);color:#fb7185;border-color:rgba(248,113,113,.35);}
+.heatmap-cell.heatmap-neutral{background:var(--heat-neutral);color:#facc15;border-color:rgba(250,204,21,.35);}
+.heatmap-cell:hover{transform:translateY(-4px);box-shadow:0 18px 36px rgba(12,18,36,.55);}
+.task-list{display:grid;gap:14px;}
+.task-item{padding:18px;border-radius:16px;background:rgba(12,20,42,.76);border:1px solid rgba(148,163,184,.2);box-shadow:var(--shadow-soft);transition:transform .2s ease,box-shadow .2s ease;}
+.task-item:hover{transform:translateY(-4px);box-shadow:0 20px 40px rgba(11,18,34,.5);}
+.task-meta{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap;}
+.task-priority{font-size:.8rem;padding:.35rem .75rem;border-radius:999px;text-transform:uppercase;letter-spacing:.08em;font-weight:700;}
+.priority-high{background:rgba(251,113,133,.28);color:#fecdd3;}
+.priority-medium{background:rgba(250,204,21,.28);color:#fef3c7;}
+.priority-low{background:rgba(34,197,94,.28);color:#dcfce7;}
+.roster-card ul{list-style:none;display:grid;gap:12px;margin-top:12px;}
+.roster-card li{display:flex;flex-direction:column;gap:6px;background:rgba(12,18,36,.72);padding:12px 14px;border-radius:12px;border:1px solid rgba(148,163,184,.16);}
+.roster-card .name{font-weight:700;color:#f8fbff;}
+.roster-card .goal{font-size:.88rem;color:rgba(226,232,255,.72);}
+.export-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;}
+.export-pre{background:rgba(6,10,24,.8);padding:1.2rem;border-radius:14px;border:1px solid rgba(148,163,184,.2);color:rgba(226,232,255,.86);font-family:var(--font-mono);max-height:360px;overflow:auto;}
+.share-preview{margin-top:12px;padding:14px;border-radius:12px;background:rgba(5,9,24,.72);border:1px solid rgba(96,165,250,.26);font-family:var(--font-mono);font-size:.9rem;white-space:pre-wrap;color:rgba(226,232,255,.84);}
+.share-buttons{display:flex;flex-wrap:wrap;gap:10px;}
+.share-buttons .btn{flex:1;min-width:140px;}
+.toast-layer{position:fixed;bottom:24px;right:24px;display:grid;gap:12px;z-index:9999;}
+.toast{background:rgba(12,18,36,.92);border-radius:14px;padding:12px 16px;border:1px solid rgba(96,165,250,.25);box-shadow:0 18px 32px rgba(11,18,34,.55);animation:toast-in .35s ease;display:flex;gap:10px;align-items:center;}
+.toast[data-tone="positive"]{border-color:rgba(74,222,128,.35);}
+.toast[data-tone="warning"]{border-color:rgba(250,204,21,.35);}
+.toast button.toast-close{background:transparent;border:none;color:rgba(226,232,255,.7);font-size:1rem;cursor:pointer;}
+@keyframes toast-in{from{opacity:0;transform:translateY(12px) scale(.96);}to{opacity:1;transform:translateY(0) scale(1);}}
+@keyframes fade-in-up{from{opacity:0;transform:translateY(10px);}to{opacity:1;transform:translateY(0);}}
+.modal-overlay{position:fixed;inset:0;background:rgba(5,8,20,.78);backdrop-filter:blur(18px);display:flex;align-items:center;justify-content:center;z-index:9998;opacity:0;pointer-events:none;transition:opacity .3s ease;}
+.modal-overlay.is-visible{opacity:1;pointer-events:auto;}
+.modal-overlay .modal-panel{background:rgba(8,13,32,.95);border-radius:20px;border:1px solid rgba(124,92,255,.35);padding:clamp(24px,4vw,32px);width:min(720px,94vw);box-shadow:0 24px 60px rgba(8,13,32,.68);display:grid;gap:18px;}
+.modal-panel header{display:flex;justify-content:space-between;align-items:center;gap:16px;}
+.modal-panel header h3{font-size:1.4rem;}
+.modal-panel .modal-body{display:grid;gap:18px;}
+.modal-panel footer{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap;}
+.checklist{display:grid;gap:12px;}
+.checklist .checklist-item{display:flex;align-items:flex-start;gap:12px;background:rgba(12,18,36,.72);padding:12px 14px;border-radius:12px;border:1px solid rgba(148,163,184,.18);cursor:pointer;transition:border-color .2s ease,box-shadow .2s ease;}
+.checklist .checklist-item:hover{border-color:rgba(124,92,255,.45);box-shadow:0 14px 30px rgba(11,18,34,.45);}
+.checklist .checklist-item strong{display:block;font-size:1rem;line-height:1.4;color:#f8fbff;}
+.checklist .checklist-item em{display:block;font-style:normal;font-size:.92rem;color:rgba(226,232,255,.75);margin-top:2px;}
+.checklist .checklist-item small{display:block;font-size:.78rem;color:rgba(148,163,184,.82);margin-top:6px;}
+.checklist input[type="checkbox"]{margin-top:4px;accent-color:#7c5cff;}
+.chip{display:inline-flex;align-items:center;gap:6px;padding:.3rem .65rem;border-radius:999px;font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;margin-top:6px;}
+.chip-high{background:rgba(239,68,68,.18);color:#fca5a5;border:1px solid rgba(248,113,113,.35);}
+.chip-medium{background:rgba(250,204,21,.18);color:#facc15;border:1px solid rgba(250,204,21,.35);}
+.chip-low{background:rgba(34,197,94,.18);color:#4ade80;border:1px solid rgba(34,197,94,.32);}
+.score-pill{display:inline-flex;align-items:center;gap:8px;padding:.45rem .85rem;border-radius:999px;font-weight:700;text-transform:uppercase;font-size:.78rem;letter-spacing:.08em;}
+.score-positive{background:rgba(34,197,94,.22);color:#4ade80;border:1px solid rgba(34,197,94,.35);}
+.score-negative{background:rgba(248,113,113,.22);color:#fca5a5;border:1px solid rgba(248,113,113,.35);}
+.score-neutral{background:rgba(250,204,21,.22);color:#facc15;border:1px solid rgba(250,204,21,.35);}
+.insight-list{list-style:none;padding:0;margin:6px 0 0;display:grid;gap:8px;}
+.insight-list li{background:rgba(12,18,36,.68);border-radius:10px;padding:10px 12px;border:1px solid rgba(148,163,184,.16);line-height:1.5;color:rgba(226,232,255,.86);}
+.insight-list mark{background:rgba(56,189,248,.25);color:#f8fafc;padding:0 4px;border-radius:4px;}
+.roster-card.pulse{animation:roster-pulse 1.4s ease;}
+@keyframes roster-pulse{0%{box-shadow:0 0 0 0 rgba(124,92,255,.4);}100%{box-shadow:0 0 0 24px rgba(124,92,255,0);}}
+.modal-overlay.visible,.modal-overlay.is-visible{opacity:1;pointer-events:auto;}
+.ats-panel{position:fixed;bottom:24px;right:24px;background:rgba(8,13,32,.92);border-radius:18px;border:1px solid rgba(124,92,255,.35);width:min(360px,90vw);box-shadow:0 24px 54px rgba(8,13,32,.6);overflow:hidden;z-index:999;}
+.ats-panel .hdr{padding:14px 18px;display:flex;justify-content:space-between;align-items:center;font-weight:700;}
+.ats-panel .act{padding:12px 18px;display:flex;align-items:center;gap:12px;border-top:1px solid rgba(148,163,184,.16);}
+.ats-panel .payload-preview{padding:16px 18px 20px;display:grid;gap:10px;}
+.ats-panel .payload-preview .row{display:flex;justify-content:space-between;font-size:.84rem;color:rgba(226,232,255,.75);}
+.ats-panel pre{margin-top:8px;max-height:160px;overflow:auto;background:rgba(5,9,24,.68);border-radius:14px;padding:12px;border:1px solid rgba(148,163,184,.18);font-family:var(--font-mono);font-size:.75rem;color:rgba(226,232,255,.7);}
+.results-card.celebrate::before,.results-card.celebrate::after{content:"";position:absolute;inset:-20%;background:conic-gradient(from 180deg,rgba(124,92,255,.15),rgba(59,130,246,.1),rgba(34,197,94,.15),rgba(124,92,255,.15));opacity:0;animation:hero-flash 1.6s ease forwards;pointer-events:none;}
+@keyframes hero-flash{0%{opacity:0;transform:scale(.8) rotate(-8deg);}60%{opacity:.65;transform:scale(1.02) rotate(0deg);}100%{opacity:0;transform:scale(1.1) rotate(12deg);}}
+@media (max-width:960px){.results-hero{grid-template-columns:1fr;justify-items:center;}.score-orb{width:clamp(200px,40vw,260px);}}
+@media (max-width:720px){.navigation-tabs{width:100%;}.navigation-tabs div{display:flex;flex-wrap:wrap;gap:8px;justify-content:center;}}
+#results-view .results-card{padding:clamp(20px,3vw,28px);}
+#results-view .results-grid{gap:clamp(18px,3vw,32px);}
+#results-view .score-value{font-size:clamp(2.4rem,4vw,3.4rem);}

--- a/index.html
+++ b/index.html
@@ -1112,7 +1112,7 @@
       }
     </style>
   </head>
-  <body>
+  <body data-stage="call">
     <a href="#survey-section" class="skip-link"> Skip to survey </a>
     <button
       id="hud-toggle-btn"
@@ -1175,24 +1175,35 @@
           role="complementary"
           aria-label="Demo instructions"
         >
-          <span class="eyebrow">Instructions</span>
-          <h2>CXI Survey Demonstration</h2>
+          <button
+            type="button"
+            class="dismiss"
+            aria-label="Hide instructions"
+            data-dismiss-instructions
+          >
+            ×
+          </button>
+          <span class="eyebrow">Run of show</span>
+          <h2>Guide your buyer through the “magic minute”</h2>
           <p>
-            Click the <strong>Leave</strong> button in the call controls to launch
-            the coffee invite and feedback survey.
+            Press <strong>Leave</strong> when you’re ready—the invite, scoring
+            ritual and dashboard reveal all fire in under 60 seconds.
           </p>
           <ul>
-            <li><strong>Stay in character:</strong> the shell mimics a live Zoom.</li>
+            <li><strong>Stage the scene:</strong> point out the live-call chrome.</li>
             <li>
-              <strong>Accept:</strong> “Free coffee? Sure!” starts the survey with
-              $5 treat framing.
+              <strong>Accept</strong> for the latte hook and instant survey
+              handoff.
             </li>
             <li>
-              <strong>Later:</strong> “Remind me in an hour” queues a nudge email
-              (demo stateful).
+              <strong>Remind me</strong> to queue a smart nudge (watch for the
+              toast).
             </li>
           </ul>
-          <footer>Need a shortcut? Prefill via console: <code>autofill()</code>.</footer>
+          <footer>
+            Need a shortcut? Prefill via console: <code>autofill()</code> or
+            <code>scoreDemo()</code>.
+          </footer>
         </aside>
         <!-- Top bar -->
         <div class="cxi-topbar" role="toolbar" aria-label="Meeting status">
@@ -1259,6 +1270,20 @@
           aria-live="polite"
           class="small ats-status"
         ></span>
+      </div>
+      <div class="payload-preview">
+        <div class="row">
+          <span>Stage</span>
+          <span id="ats-stage">Panel</span>
+        </div>
+        <div class="row">
+          <span>Role</span>
+          <span id="ats-role">Backend SWE</span>
+        </div>
+        <div class="row">
+          <span>Token</span>
+          <span id="ats-token">cand_demo</span>
+        </div>
       </div>
       <pre id="ats-json" aria-live="polite">{}</pre>
     </aside>
@@ -1729,105 +1754,128 @@
       <!-- Summary Tab -->
       <div id="summary-tab">
         <div class="results-grid">
-          <div class="results-card">
-            <div class="score-display">
-              <div class="score-label">Net Sentiment Score</div>
-              <div class="score-value success" id="nss-display">+0.75</div>
-              <div class="band-indicator band-success" id="nss-band">
-                Positive
+          <div class="results-card highlight-card" id="results-hero-card">
+            <div class="results-hero">
+              <div class="score-orb" id="score-orb">
+                <span class="orb-value" id="orb-score">82</span>
+                <span class="orb-label">Composite Index</span>
+                <div class="orb-band">
+                  <span id="orb-band-label">Success</span>
+                </div>
+              </div>
+              <div class="hero-metric-grid">
+                <div class="metric-tile">
+                  <div>
+                    <div class="metric-label">Net Sentiment Score</div>
+                    <div class="metric-value" id="nss-display">+0.75</div>
+                  </div>
+                  <div class="band-indicator band-success" id="nss-band">
+                    Positive
+                  </div>
+                </div>
+                <div class="metric-tile">
+                  <div>
+                    <div class="metric-label">Quality Signal</div>
+                    <div class="metric-value" id="quality-score">92%</div>
+                  </div>
+                  <div class="band-indicator band-success" id="quality-band">
+                    Eligible
+                  </div>
+                </div>
+                <div class="metric-tile">
+                  <div>
+                    <div class="metric-label">Attention</div>
+                    <div class="metric-value" id="attention-score">4.8</div>
+                  </div>
+                  <div class="band-indicator band-success" id="attention-band">
+                    High
+                  </div>
+                </div>
               </div>
             </div>
+            <div
+              class="transcript-playback"
+              id="transcript-playback"
+              aria-live="polite"
+            ></div>
+          </div>
+
+          <div class="results-card" id="insight-card">
+            <h3>✨ Signal Highlights</h3>
             <div class="highlights-section">
-              <h4>Key Phrases</h4>
-              <div id="highlights-display">
+              <div id="highlights-display" class="highlight-stream">
                 <span class="highlight-item highlight-positive"
                   >clear communication</span
                 >
-                <span class="highlight-item highlight-positive"
-                  >responsive team</span
-                >
-                <span class="highlight-item highlight-negative"
-                  >slow feedback</span
-                >
               </div>
+            </div>
+            <div class="highlights-section mt-1">
+              <h4>Aspect Pulse</h4>
+              <div class="absa-tags" id="absa-display"></div>
             </div>
           </div>
 
-          <div class="results-card">
-            <div class="score-display">
-              <div class="score-label">Composite Index</div>
-              <div class="score-value success" id="index-display">0.82</div>
-              <div class="band-indicator band-success" id="index-band">
-                Success
+          <div class="results-card" id="summary-card">
+            <h3>📝 Narrative &amp; Coaching</h3>
+            <div id="summary-text">
+              <p>
+                <strong>Summary:</strong>
+                <span id="response-summary"
+                  >Positive experience at panel stage. Strengths: communication,
+                  clarity. Areas for improvement: feedback timeliness.</span
+                >
+              </p>
+              <div class="task-coaching">
+                <strong>Coaching Cue:</strong>
+                <span id="coaching-cue"
+                  >Set feedback SLA ≤3 business days for panel stage.</span
+                >
               </div>
-            </div>
-            <div class="highlights-section">
-              <h4>ABSA Analysis</h4>
-              <div class="absa-tags" id="absa-display">
-                <span class="absa-tag absa-positive">Communication</span>
-                <span class="absa-tag absa-positive">Clarity</span>
-                <span class="absa-tag absa-negative">Feedback Timeline</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="results-card">
-          <h3>📝 Summary & Coaching</h3>
-          <div id="summary-text">
-            <p>
-              <strong>Summary:</strong>
-              <span id="response-summary"
-                >Positive experience at panel stage. Strengths: communication,
-                clarity. Areas for improvement: feedback timeliness.</span
-              >
-            </p>
-            <div class="task-coaching">
-              <strong>Coaching Cue:</strong>
-              <span id="coaching-cue"
-                >Set feedback SLA ≤3 business days for panel stage.</span
-              >
-            </div>
-            <div id="quality-block" class="mt-1" hidden>
-              <div class="small muted" id="quality-flags"></div>
-              <div class="quality-row">
-                <div id="results-live" aria-live="polite" aria-atomic="true">
-                  <span id="quality-badge" class="quality-badge"
-                    ><svg aria-hidden="true" width="14" height="14">
-                      <use href="#icon-info" />
-                    </svg>
-                    <span class="qb-text">Quality: --</span></span
-                  >
+              <div id="quality-block" class="mt-1" hidden>
+                <div class="small muted" id="quality-flags"></div>
+                <div class="quality-row">
+                  <div id="results-live" aria-live="polite" aria-atomic="true">
+                    <span id="quality-badge" class="quality-badge"
+                      ><svg aria-hidden="true" width="14" height="14">
+                        <use href="#icon-info" />
+                      </svg>
+                      <span class="qb-text">Quality: --</span></span
+                    >
+                  </div>
+                  <span id="incentive-eligibility" class="small ml-1"></span>
                 </div>
-                <span id="incentive-eligibility" class="small ml-1"></span>
               </div>
             </div>
-          </div>
-          <div class="mt-1">
-            <button class="btn btn-primary" onclick="pushToDashboard()">
-              Push to Dashboard
-            </button>
-            <button class="btn btn-ghost" onclick="resetDemo()">
-              Reset Sample
-            </button>
-          </div>
-        </div>
-
-        <div class="results-card" id="ctr-card">
-          <div class="ctr-hdr">
-            <h3 class="no-m">📈 Invite CTR</h3>
-            <div>
-              <label class="small" for="ctr-days-select">Range</label>
-              <select id="ctr-days-select" class="small" aria-label="CTR range">
-                <option value="7" selected>Last 7 days</option>
-                <option value="14">Last 14 days</option>
-                <option value="30">Last 30 days</option>
-              </select>
+            <div class="mt-1 action-row">
+              <button class="btn btn-primary" onclick="pushToDashboard()">
+                Push to Dashboard
+              </button>
+              <button class="btn btn-ghost" onclick="resetDemo()">
+                Reset Sample
+              </button>
             </div>
           </div>
-          <div class="muted small">Views vs Accepts by invite variant</div>
-          <div id="ctr-summary" class="mt-1 muted">Loading…</div>
-          <div id="ctr-breakdown" class="mt-1 small"></div>
+
+          <div class="results-card" id="ctr-card">
+            <div class="ctr-hdr">
+              <h3 class="no-m">📈 Invite CTR</h3>
+              <div>
+                <label class="small" for="ctr-days-select">Range</label>
+                <select
+                  id="ctr-days-select"
+                  class="small"
+                  aria-label="CTR range"
+                >
+                  <option value="7" selected>Last 7 days</option>
+                  <option value="14">Last 14 days</option>
+                  <option value="30">Last 30 days</option>
+                </select>
+              </div>
+            </div>
+            <div class="muted small">Views vs Accepts by invite variant</div>
+            <div id="ctr-summary" class="mt-1 muted">Loading…</div>
+            <div id="ctr-breakdown" class="mt-1 small"></div>
+          </div>
         </div>
       </div>
 
@@ -1840,242 +1888,341 @@
             negative sentiment.
           </p>
 
-          <div class="heatmap-grid" id="heatmap-grid">
-            <!-- Headers -->
-            <div class="heatmap-header"></div>
-            <div class="heatmap-header">Applied</div>
-            <div class="heatmap-header">Recruiter</div>
-            <div class="heatmap-header">Hiring Mgr</div>
-            <div class="heatmap-header">Panel</div>
-            <div class="heatmap-header">Assignment</div>
-            <div class="heatmap-header">Offer</div>
-            <div class="heatmap-header">Rejected</div>
+        <div class="heatmap-grid" id="heatmap-grid">
+          <div class="heatmap-header"></div>
+          <div class="heatmap-header">Applied</div>
+          <div class="heatmap-header">Recruiter</div>
+          <div class="heatmap-header">Hiring Mgr</div>
+          <div class="heatmap-header">Panel</div>
+          <div class="heatmap-header">Assignment</div>
+          <div class="heatmap-header">Offer</div>
+          <div class="heatmap-header">Rejected</div>
 
-            <!-- Communication Row -->
-            <div class="heatmap-row-label">Communication</div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('communication', 'applied')"
-            >
-              +0.8
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('communication', 'recruiter')"
-            >
-              +0.6
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('communication', 'hiring_manager')"
-            >
-              +0.7
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('communication', 'panel')"
-            >
-              +0.5
-            </div>
-            <div
-              class="heatmap-cell heatmap-neutral"
-              onclick="showHeatmapDetail('communication', 'assignment')"
-            >
-              +0.2
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('communication', 'offer')"
-            >
-              +0.9
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('communication', 'rejected')"
-            >
-              -0.3
-            </div>
-
-            <!-- Scheduling Row -->
-            <div class="heatmap-row-label">Scheduling</div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('scheduling', 'applied')"
-            >
-              +0.9
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('scheduling', 'recruiter')"
-            >
-              +0.4
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('scheduling', 'hiring_manager')"
-            >
-              -0.2
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('scheduling', 'panel')"
-            >
-              -0.4
-            </div>
-            <div
-              class="heatmap-cell heatmap-neutral"
-              onclick="showHeatmapDetail('scheduling', 'assignment')"
-            >
-              +0.1
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('scheduling', 'offer')"
-            >
-              +0.7
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('scheduling', 'rejected')"
-            >
-              -0.6
-            </div>
-
-            <!-- Clarity Row -->
-            <div class="heatmap-row-label">Clarity</div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('clarity', 'applied')"
-            >
-              +0.6
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('clarity', 'recruiter')"
-            >
-              +0.8
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('clarity', 'hiring_manager')"
-            >
-              +0.3
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('clarity', 'panel')"
-            >
-              -0.1
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('clarity', 'assignment')"
-            >
-              -0.3
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('clarity', 'offer')"
-            >
-              +0.8
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('clarity', 'rejected')"
-            >
-              -0.5
-            </div>
-
-            <!-- Respect Row -->
-            <div class="heatmap-row-label">Respect</div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('respect', 'applied')"
-            >
-              +0.9
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('respect', 'recruiter')"
-            >
-              +0.7
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('respect', 'hiring_manager')"
-            >
-              +0.8
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('respect', 'panel')"
-            >
-              +0.6
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('respect', 'assignment')"
-            >
-              +0.4
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('respect', 'offer')"
-            >
-              +0.9
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('respect', 'rejected')"
-            >
-              -0.2
-            </div>
-
-            <!-- Feedback Timeline Row -->
-            <div class="heatmap-row-label">Feedback</div>
-            <div
-              class="heatmap-cell heatmap-neutral"
-              onclick="showHeatmapDetail('feedback', 'applied')"
-            >
-              +0.1
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('feedback', 'recruiter')"
-            >
-              -0.2
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('feedback', 'hiring_manager')"
-            >
-              -0.4
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('feedback', 'panel')"
-            >
-              -0.6
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('feedback', 'assignment')"
-            >
-              -0.8
-            </div>
-            <div
-              class="heatmap-cell heatmap-positive"
-              onclick="showHeatmapDetail('feedback', 'offer')"
-            >
-              +0.5
-            </div>
-            <div
-              class="heatmap-cell heatmap-negative"
-              onclick="showHeatmapDetail('feedback', 'rejected')"
-            >
-              -0.9
-            </div>
+          <div class="heatmap-row-label">Communication</div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="communication"
+            data-stage="applied"
+            data-label="Applied"
+            onclick="showHeatmapDetail('communication', 'applied')"
+          >
+            +0.8
           </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="communication"
+            data-stage="recruiter"
+            data-label="Recruiter"
+            onclick="showHeatmapDetail('communication', 'recruiter')"
+          >
+            +0.6
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="communication"
+            data-stage="hiring_manager"
+            data-label="Hiring Mgr"
+            onclick="showHeatmapDetail('communication', 'hiring_manager')"
+          >
+            +0.7
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="communication"
+            data-stage="panel"
+            data-label="Panel"
+            onclick="showHeatmapDetail('communication', 'panel')"
+          >
+            +0.5
+          </div>
+          <div
+            class="heatmap-cell heatmap-neutral"
+            data-aspect="communication"
+            data-stage="assignment"
+            data-label="Assignment"
+            onclick="showHeatmapDetail('communication', 'assignment')"
+          >
+            +0.2
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="communication"
+            data-stage="offer"
+            data-label="Offer"
+            onclick="showHeatmapDetail('communication', 'offer')"
+          >
+            +0.9
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="communication"
+            data-stage="rejected"
+            data-label="Rejected"
+            onclick="showHeatmapDetail('communication', 'rejected')"
+          >
+            -0.3
+          </div>
+
+          <div class="heatmap-row-label">Scheduling</div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="scheduling"
+            data-stage="applied"
+            data-label="Applied"
+            onclick="showHeatmapDetail('scheduling', 'applied')"
+          >
+            +0.9
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="scheduling"
+            data-stage="recruiter"
+            data-label="Recruiter"
+            onclick="showHeatmapDetail('scheduling', 'recruiter')"
+          >
+            +0.4
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="scheduling"
+            data-stage="hiring_manager"
+            data-label="Hiring Mgr"
+            onclick="showHeatmapDetail('scheduling', 'hiring_manager')"
+          >
+            -0.2
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="scheduling"
+            data-stage="panel"
+            data-label="Panel"
+            onclick="showHeatmapDetail('scheduling', 'panel')"
+          >
+            -0.4
+          </div>
+          <div
+            class="heatmap-cell heatmap-neutral"
+            data-aspect="scheduling"
+            data-stage="assignment"
+            data-label="Assignment"
+            onclick="showHeatmapDetail('scheduling', 'assignment')"
+          >
+            +0.1
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="scheduling"
+            data-stage="offer"
+            data-label="Offer"
+            onclick="showHeatmapDetail('scheduling', 'offer')"
+          >
+            +0.7
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="scheduling"
+            data-stage="rejected"
+            data-label="Rejected"
+            onclick="showHeatmapDetail('scheduling', 'rejected')"
+          >
+            -0.6
+          </div>
+
+          <div class="heatmap-row-label">Clarity</div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="clarity"
+            data-stage="applied"
+            data-label="Applied"
+            onclick="showHeatmapDetail('clarity', 'applied')"
+          >
+            +0.6
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="clarity"
+            data-stage="recruiter"
+            data-label="Recruiter"
+            onclick="showHeatmapDetail('clarity', 'recruiter')"
+          >
+            +0.8
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="clarity"
+            data-stage="hiring_manager"
+            data-label="Hiring Mgr"
+            onclick="showHeatmapDetail('clarity', 'hiring_manager')"
+          >
+            +0.3
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="clarity"
+            data-stage="panel"
+            data-label="Panel"
+            onclick="showHeatmapDetail('clarity', 'panel')"
+          >
+            -0.1
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="clarity"
+            data-stage="assignment"
+            data-label="Assignment"
+            onclick="showHeatmapDetail('clarity', 'assignment')"
+          >
+            -0.3
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="clarity"
+            data-stage="offer"
+            data-label="Offer"
+            onclick="showHeatmapDetail('clarity', 'offer')"
+          >
+            +0.8
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="clarity"
+            data-stage="rejected"
+            data-label="Rejected"
+            onclick="showHeatmapDetail('clarity', 'rejected')"
+          >
+            -0.5
+          </div>
+
+          <div class="heatmap-row-label">Respect</div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="respect"
+            data-stage="applied"
+            data-label="Applied"
+            onclick="showHeatmapDetail('respect', 'applied')"
+          >
+            +0.9
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="respect"
+            data-stage="recruiter"
+            data-label="Recruiter"
+            onclick="showHeatmapDetail('respect', 'recruiter')"
+          >
+            +0.7
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="respect"
+            data-stage="hiring_manager"
+            data-label="Hiring Mgr"
+            onclick="showHeatmapDetail('respect', 'hiring_manager')"
+          >
+            +0.8
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="respect"
+            data-stage="panel"
+            data-label="Panel"
+            onclick="showHeatmapDetail('respect', 'panel')"
+          >
+            +0.6
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="respect"
+            data-stage="assignment"
+            data-label="Assignment"
+            onclick="showHeatmapDetail('respect', 'assignment')"
+          >
+            +0.4
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="respect"
+            data-stage="offer"
+            data-label="Offer"
+            onclick="showHeatmapDetail('respect', 'offer')"
+          >
+            +0.9
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="respect"
+            data-stage="rejected"
+            data-label="Rejected"
+            onclick="showHeatmapDetail('respect', 'rejected')"
+          >
+            -0.2
+          </div>
+
+          <div class="heatmap-row-label">Feedback</div>
+          <div
+            class="heatmap-cell heatmap-neutral"
+            data-aspect="feedback"
+            data-stage="applied"
+            data-label="Applied"
+            onclick="showHeatmapDetail('feedback', 'applied')"
+          >
+            +0.1
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="feedback"
+            data-stage="recruiter"
+            data-label="Recruiter"
+            onclick="showHeatmapDetail('feedback', 'recruiter')"
+          >
+            -0.2
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="feedback"
+            data-stage="hiring_manager"
+            data-label="Hiring Mgr"
+            onclick="showHeatmapDetail('feedback', 'hiring_manager')"
+          >
+            -0.4
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="feedback"
+            data-stage="panel"
+            data-label="Panel"
+            onclick="showHeatmapDetail('feedback', 'panel')"
+          >
+            -0.6
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="feedback"
+            data-stage="assignment"
+            data-label="Assignment"
+            onclick="showHeatmapDetail('feedback', 'assignment')"
+          >
+            -0.8
+          </div>
+          <div
+            class="heatmap-cell heatmap-positive"
+            data-aspect="feedback"
+            data-stage="offer"
+            data-label="Offer"
+            onclick="showHeatmapDetail('feedback', 'offer')"
+          >
+            +0.5
+          </div>
+          <div
+            class="heatmap-cell heatmap-negative"
+            data-aspect="feedback"
+            data-stage="rejected"
+            data-label="Rejected"
+            onclick="showHeatmapDetail('feedback', 'rejected')"
+          >
+            -0.9
+          </div>
+        </div>
         </div>
 
         <div id="heatmap-detail" class="results-card hidden">
@@ -2123,10 +2270,45 @@
           </div>
         </div>
 
+        <div class="results-card roster-card" id="interviewer-roster">
+          <h4>Interview Team Coaching Focus</h4>
+          <ul>
+            <li>
+              <span class="name">Jason R.</span>
+              <span class="goal">Weekly goal: SLA &lt; 48 hours feedback.</span>
+            </li>
+            <li>
+              <span class="name">Jess D.</span>
+              <span class="goal"
+                >Communication must clearly outline the role and agenda.</span
+              >
+            </li>
+            <li>
+              <span class="name">Priya K.</span>
+              <span class="goal"
+                >Ensure technical debriefs include action-ready notes for hiring
+                managers.</span
+              >
+            </li>
+            <li>
+              <span class="name">Amelia S.</span>
+              <span class="goal"
+                >Build consistent rubric talk-throughs to set candidate
+                expectations.</span
+              >
+            </li>
+          </ul>
+        </div>
+
         <div class="task-list" id="task-list">
           <div class="task-header">Active Tasks (3)</div>
 
-          <div class="task-item" data-stage="panel" data-priority="high">
+          <div
+            class="task-item"
+            data-stage="panel"
+            data-priority="high"
+            data-age-minutes="120"
+          >
             <div class="task-meta">
               <div>
                 <span class="task-priority priority-high">High</span>
@@ -2143,7 +2325,12 @@
             </div>
           </div>
 
-          <div class="task-item" data-stage="recruiter" data-priority="medium">
+          <div
+            class="task-item"
+            data-stage="recruiter"
+            data-priority="medium"
+            data-age-minutes="300"
+          >
             <div class="task-meta">
               <div>
                 <span class="task-priority priority-medium">Medium</span>
@@ -2159,7 +2346,12 @@
             </div>
           </div>
 
-          <div class="task-item" data-stage="offer" data-priority="low">
+          <div
+            class="task-item"
+            data-stage="offer"
+            data-priority="low"
+            data-age-minutes="1440"
+          >
             <div class="task-meta">
               <div>
                 <span class="task-priority priority-low">Low</span>
@@ -2208,6 +2400,120 @@
       </div>
     </div>
 
+    <div
+      id="score-reveal"
+      class="score-reveal"
+      role="dialog"
+      aria-modal="true"
+      aria-live="assertive"
+      hidden
+    >
+      <div class="score-reveal__panel">
+        <button
+          type="button"
+          class="score-reveal__close"
+          data-close-reveal
+          aria-label="Dismiss score reveal"
+        >
+          ×
+        </button>
+        <span class="score-reveal__eyebrow">Magic minute</span>
+        <h2 class="score-reveal__headline">Signal spell complete ✨</h2>
+        <div class="score-reveal__grid">
+          <div class="score-reveal__metric">
+            <span class="label">Composite Index</span>
+            <span class="value" data-reveal-index>0</span>
+          </div>
+          <div class="score-reveal__metric">
+            <span class="label">Net Sentiment</span>
+            <span class="value" data-reveal-nss>+0.00</span>
+          </div>
+          <div class="score-reveal__metric">
+            <span class="label">Quality Gate</span>
+            <span class="value" data-reveal-quality>0%</span>
+          </div>
+        </div>
+        <div class="score-reveal__summary" data-reveal-summary>
+          Candidate sentiment landed positive at the panel stage. Strengths:
+          communication &amp; clarity. Focus next: feedback cadence.
+        </div>
+        <div class="score-reveal__stage">
+          <span data-reveal-stage>Panel Interview</span>
+          <span class="band-pill" data-reveal-band>Success</span>
+        </div>
+        <div class="score-reveal__aspects" data-reveal-aspects>
+          <span>Communication</span><span>Clarity</span>
+        </div>
+        <div class="score-reveal__sentence" data-reveal-sentence>
+          Panel started on time with clear introductions and respectful tone
+          throughout.
+        </div>
+        <div class="score-reveal__actions">
+          <button type="button" class="btn btn-ghost" data-close-reveal>
+            Skip animation
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-reveal-open-dashboard
+          >
+            Open full dashboard
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Dashboard share modal -->
+    <div
+      id="dashboard-modal"
+      class="modal-overlay"
+      role="presentation"
+      hidden
+    >
+      <div
+        class="modal-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dashboard-modal-title"
+      >
+        <header>
+          <h3 id="dashboard-modal-title">Push to CXI Dashboard</h3>
+          <button
+            type="button"
+            class="btn btn-ghost"
+            data-close-dashboard
+            aria-label="Close push-to-dashboard modal"
+          >
+            ×
+          </button>
+        </header>
+        <div id="dashboard-modal-summary" class="muted small">
+          Coaching tasks staged for review.
+        </div>
+        <div class="modal-body">
+          <div class="checklist" id="dashboard-task-list"></div>
+          <div>
+            <h4>Share instantly</h4>
+            <div class="share-buttons">
+              <button class="btn btn-primary" data-share="email">Email</button>
+              <button class="btn btn-primary" data-share="slack">Slack</button>
+              <button class="btn btn-primary" data-share="teams">Teams</button>
+              <button class="btn btn-primary" data-share="pdf">Export PDF</button>
+            </div>
+            <div class="share-preview" id="share-preview" hidden></div>
+          </div>
+        </div>
+        <footer>
+          <button class="btn btn-ghost" data-action="copy-checklist">
+            Copy selected tasks
+          </button>
+          <button class="btn btn-primary" data-close-dashboard>Done</button>
+        </footer>
+      </div>
+    </div>
+
+    <div id="toast-layer" class="toast-layer" aria-live="polite"></div>
+
     <script>
       let currentStage = "call";
       let isRecording = false;
@@ -2235,6 +2541,7 @@
       // Zoom Call Functions
       function showStage(stage) {
         currentStage = stage;
+        document.body.dataset.stage = stage;
         // Hide all major views
         ["interview-view", "survey-view", "results-view"].forEach((id) => {
           const el = document.getElementById(id);
@@ -2254,6 +2561,10 @@
         // Auto-load summary metrics when landing on results
         if (stage === "results" && typeof loadCtrMetrics === "function") {
           loadCtrMetrics();
+          requestAnimationFrame(() => {
+            document.getElementById("results-view")?.scrollTo?.(0, 0);
+            window.scrollTo({ top: 0, behavior: "smooth" });
+          });
         }
 
         // Update hash
@@ -2654,6 +2965,24 @@
         }, 1000);
       }
 
+      function showToast(message, tone = "positive") {
+        const layer = document.getElementById("toast-layer");
+        if (!layer) return;
+        const toast = document.createElement("div");
+        toast.className = "toast";
+        toast.dataset.tone = tone;
+        toast.innerHTML = `<span>${message}</span><button type="button" class="toast-close" aria-label="Dismiss notification">×</button>`;
+        const closeBtn = toast.querySelector(".toast-close");
+        const dismiss = () => {
+          toast.classList.add("hiding");
+          setTimeout(() => toast.remove(), 200);
+        };
+        closeBtn?.addEventListener("click", dismiss);
+        layer.appendChild(toast);
+        setTimeout(dismiss, 4200);
+      }
+      window.__cxToast = showToast;
+
       /* Inline fallback functions for when modules don't load properly */
       function updateWordCount(textareaId, countId) {
         const textarea = document.getElementById(textareaId);
@@ -2755,7 +3084,6 @@
       }
 
       function enforceExactWords(textareaId, countId, exact) {
-        console.log('enforceExactWords called (fallback)');
         const ta = document.getElementById(textareaId);
         if (!ta) return;
         const words = ta.value.trim().match(/\S+/g) || [];
@@ -2778,6 +3106,53 @@
       
       document.addEventListener("DOMContentLoaded", function () {
         init();
+        const inlineCta = document.getElementById("inline-cta");
+        if (inlineCta && inlineCta.dataset.managed !== "true") {
+          inlineCta.dataset.managed = "true";
+          let fadeTimer;
+          let hideTimer;
+          const clearTimers = () => {
+            clearTimeout(fadeTimer);
+            clearTimeout(hideTimer);
+          };
+          const scheduleTimers = () => {
+            clearTimers();
+            fadeTimer = setTimeout(() => {
+              inlineCta.setAttribute("data-state", "fading");
+            }, 9000);
+            hideTimer = setTimeout(() => {
+              inlineCta.setAttribute("data-hidden", "true");
+            }, 15000);
+          };
+          const revealPlacard = () => {
+            inlineCta.removeAttribute("data-state");
+            inlineCta.removeAttribute("data-hidden");
+          };
+          const dismissPlacard = () => {
+            clearTimers();
+            inlineCta.removeAttribute("data-state");
+            inlineCta.setAttribute("data-hidden", "true");
+          };
+          scheduleTimers();
+          inlineCta.addEventListener("mouseenter", () => {
+            revealPlacard();
+            clearTimers();
+          });
+          inlineCta.addEventListener("focusin", () => {
+            revealPlacard();
+            clearTimers();
+          });
+          inlineCta.addEventListener("mouseleave", () => {
+            if (inlineCta.getAttribute("data-hidden") === "true") return;
+            scheduleTimers();
+          });
+          inlineCta.addEventListener("focusout", () => {
+            if (!inlineCta.contains(document.activeElement)) scheduleTimers();
+          });
+          inlineCta
+            .querySelector("[data-dismiss-instructions]")
+            ?.addEventListener("click", dismissPlacard);
+        }
         // Show HUD toggle only when ?debug=1
         try {
           const debug = new URL(location.href).searchParams.get("debug");
@@ -3478,7 +3853,7 @@
         .getElementById("cxi-cta-remind")
         .addEventListener("click", () => {
           const st = getNudgeState();
-          const plan = [4, 24, 72];
+          const plan = [1, 24, 72];
           const nextIdx = Math.min(st.count, plan.length - 1);
           if (typeof track === "function")
             track("remind", {
@@ -3487,6 +3862,11 @@
               variant: window.__cxiVariantKey,
             });
           scheduleNudge(plan[nextIdx]);
+          if (typeof showToast === "function") {
+            const hours = plan[nextIdx];
+            const label = hours === 1 ? "one hour" : `${hours} hours`;
+            showToast(`We\'ll send a nudge in ${label}.`, "warning");
+          }
           closeInvite();
         });
       document
@@ -3536,6 +3916,13 @@
 
       // ATS webhook simulator
       function showATSWebhook(stage, role, token) {
+        let debugMode = false;
+        try {
+          debugMode = new URL(location.href).searchParams.get("debug") === "1";
+        } catch (_) {
+          debugMode = false;
+        }
+        if (!debugMode) return;
         const payload = {
           event: "candidate_feedback_invite",
           stage,
@@ -3547,6 +3934,12 @@
         };
         const el = document.getElementById("ats-json");
         const panel = document.getElementById("ats-panel");
+        const stageEl = document.getElementById("ats-stage");
+        const roleEl = document.getElementById("ats-role");
+        const tokenEl = document.getElementById("ats-token");
+        if (stageEl) stageEl.textContent = stage;
+        if (roleEl) roleEl.textContent = role;
+        if (tokenEl) tokenEl.textContent = payload.candidate_token;
         if (el && panel) {
           el.textContent = JSON.stringify(payload, null, 2);
           panel.hidden = false;

--- a/js/app.js
+++ b/js/app.js
@@ -8,7 +8,12 @@ import {
   showResultsTab,
   updateProgress,
 } from "./survey.js";
-import { performanceMark } from "./utils.js";
+import {
+  animateNumber,
+  performanceMark,
+  seededRandom,
+  typewriter,
+} from "./utils.js";
 
 window.showResultsTab = showResultsTab;
 if (typeof window.openInvite !== "function") {
@@ -26,6 +31,9 @@ function ensureDashboard() {
     window.showHeatmapDetail = mod.showHeatmapDetail;
     window.filterTasks = mod.filterTasks;
     window.pushToDashboard = mod.pushToDashboard;
+    if (mod.updateRosterHighlight) {
+      window.updateRosterHighlight = mod.updateRosterHighlight;
+    }
     window.__dashboardLoaded = true;
   });
 }
@@ -45,6 +53,196 @@ function initCandidateToken() {
   const existing = url.searchParams.get("token");
   window.CANDIDATE_TOKEN =
     existing || "cand_" + Math.random().toString(36).slice(2, 10).toLowerCase();
+}
+
+let instructionTimers = { fade: 0, hide: 0 };
+function setupInstructionPlacard() {
+  const placard = document.getElementById("inline-cta");
+  if (!placard) return;
+  if (placard.dataset.managed === "true") return;
+  placard.dataset.managed = "true";
+  const clearTimers = () => {
+    clearTimeout(instructionTimers.fade);
+    clearTimeout(instructionTimers.hide);
+  };
+  const schedule = () => {
+    clearTimers();
+    instructionTimers.fade = window.setTimeout(() => {
+      placard.setAttribute("data-state", "fading");
+    }, 9000);
+    instructionTimers.hide = window.setTimeout(() => {
+      placard.setAttribute("data-hidden", "true");
+    }, 15000);
+  };
+  const reveal = () => {
+    placard.removeAttribute("data-state");
+    placard.removeAttribute("data-hidden");
+  };
+  const dismiss = () => {
+    clearTimers();
+    placard.removeAttribute("data-state");
+    placard.setAttribute("data-hidden", "true");
+  };
+  schedule();
+  placard.addEventListener("mouseenter", () => {
+    reveal();
+    clearTimers();
+  });
+  placard.addEventListener("focusin", () => {
+    reveal();
+    clearTimers();
+  });
+  placard.addEventListener("mouseleave", () => {
+    if (placard.getAttribute("data-hidden") === "true") return;
+    schedule();
+  });
+  placard.addEventListener("focusout", () => {
+    if (!placard.contains(document.activeElement)) schedule();
+  });
+  placard
+    .querySelector("[data-dismiss-instructions]")
+    ?.addEventListener("click", dismiss);
+}
+
+let scoreRevealEl = null;
+const scoreRevealTimers = new Set();
+
+function clearScoreRevealTimers() {
+  scoreRevealTimers.forEach((id) => clearTimeout(id));
+  scoreRevealTimers.clear();
+}
+
+function hideScoreReveal() {
+  if (!scoreRevealEl) return;
+  clearScoreRevealTimers();
+  scoreRevealEl.classList.remove("is-visible");
+  scoreRevealEl.setAttribute("aria-hidden", "true");
+  const el = scoreRevealEl;
+  window.setTimeout(() => {
+    el.hidden = true;
+  }, 240);
+}
+
+function setupScoreReveal() {
+  scoreRevealEl = document.getElementById("score-reveal");
+  if (!scoreRevealEl) return;
+  scoreRevealEl.hidden = true;
+  scoreRevealEl.setAttribute("aria-hidden", "true");
+  scoreRevealEl.addEventListener("click", (evt) => {
+    if (evt.target === scoreRevealEl) hideScoreReveal();
+  });
+  scoreRevealEl
+    .querySelectorAll("[data-close-reveal]")
+    .forEach((btn) => btn.addEventListener("click", hideScoreReveal));
+  const jumpBtn = scoreRevealEl.querySelector(
+    "[data-reveal-open-dashboard]",
+  );
+  if (jumpBtn) {
+    jumpBtn.addEventListener("click", () => {
+      hideScoreReveal();
+      showResultsTab("summary");
+      document
+        .getElementById("results-view")
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  }
+  window.dismissScoreReveal = hideScoreReveal;
+}
+
+function highlightRevealSentence(sentence = "", aspects = []) {
+  if (!scoreRevealEl) return;
+  const target = scoreRevealEl.querySelector("[data-reveal-sentence]");
+  if (!target) return;
+  const cleaned = (sentence || "").trim();
+  if (!cleaned) {
+    target.textContent =
+      "NSS translator will light up once a candidate story streams in.";
+    return;
+  }
+  target.textContent = cleaned;
+  const keywords = (aspects || [])
+    .map((aspect) => formatAspect(aspect).toLowerCase())
+    .filter(Boolean)
+    .flatMap((word) => [word, word.replace(/\s+/g, "")]);
+  const timer = window.setTimeout(() => {
+    const tokens = cleaned.split(/(\s+)/);
+    target.innerHTML = tokens
+      .map((token) => {
+        const normalized = token
+          .toLowerCase()
+          .replace(/[^a-z0-9]/g, "");
+        const hit = keywords.some((kw) =>
+          normalized.includes(kw.replace(/[^a-z0-9]/g, "")),
+        );
+        return hit && token.trim()
+          ? `<mark>${token}</mark>`
+          : token;
+      })
+      .join("");
+  }, 720);
+  scoreRevealTimers.add(timer);
+}
+
+function triggerScoreReveal(context) {
+  if (!scoreRevealEl) return;
+  clearScoreRevealTimers();
+  scoreRevealEl.hidden = false;
+  scoreRevealEl.setAttribute("aria-hidden", "false");
+  requestAnimationFrame(() => scoreRevealEl.classList.add("is-visible"));
+  const indexEl = scoreRevealEl.querySelector("[data-reveal-index]");
+  const nssEl = scoreRevealEl.querySelector("[data-reveal-nss]");
+  const qualityEl = scoreRevealEl.querySelector("[data-reveal-quality]");
+  if (indexEl)
+    animateNumber(indexEl, {
+      from: 0,
+      to: Number(context.index || 0) * 100,
+      duration: 900,
+      decimals: 0,
+    });
+  if (nssEl)
+    animateNumber(nssEl, {
+      from: 0,
+      to: Number(context.nss || 0),
+      duration: 900,
+      decimals: 2,
+      prefix: context.nss >= 0 ? "+" : "",
+    });
+  if (qualityEl)
+    animateNumber(qualityEl, {
+      from: 0,
+      to: Number(context.quality || 0) * 100,
+      duration: 900,
+      decimals: 0,
+      suffix: "%",
+    });
+  const summaryEl = scoreRevealEl.querySelector("[data-reveal-summary]");
+  if (summaryEl) {
+    summaryEl.textContent = context.summary || "Fresh signal incoming.";
+    summaryEl.classList.remove("is-highlighted");
+    const t = window.setTimeout(
+      () => summaryEl.classList.add("is-highlighted"),
+      520,
+    );
+    scoreRevealTimers.add(t);
+  }
+  const stageEl = scoreRevealEl.querySelector("[data-reveal-stage]");
+  if (stageEl) stageEl.textContent = formatStage(context.stage);
+  const bandEl = scoreRevealEl.querySelector("[data-reveal-band]");
+  if (bandEl)
+    bandEl.textContent =
+      context.band || (context.index >= 0.7 ? "Success" : "Watch");
+  const aspectsEl = scoreRevealEl.querySelector("[data-reveal-aspects]");
+  if (aspectsEl) {
+    const aspects = Array.isArray(context.aspects) ? context.aspects : [];
+    const chips = aspects
+      .slice(0, 4)
+      .map((aspect) => `<span>${formatAspect(aspect)}</span>`)
+      .join("");
+    aspectsEl.innerHTML = chips || '<span>Candidate Delight</span>';
+  }
+  highlightRevealSentence(context.sentence, context.aspects);
+  const hideTimer = window.setTimeout(hideScoreReveal, 10000);
+  scoreRevealTimers.add(hideTimer);
 }
 
 function wireSurvey() {
@@ -117,6 +315,7 @@ function wireSubmission() {
   });
 }
 
+
 function displayResults(data) {
   performanceMark("results_display");
   if (typeof window.showStage === "function") {
@@ -127,103 +326,329 @@ function displayResults(data) {
     const resultsView = document.getElementById("results-view");
     if (resultsView) resultsView.classList.remove("hidden");
   }
-  const { bands = {}, composite_index = 0 } = data;
-  const overallEl = qs("overall-score");
-  if (overallEl)
-    overallEl.textContent = (composite_index * 100).toFixed(0) + "";
-  qs("band-overall").textContent = bands.overall || "N/A";
-  qs("band-fairness").textContent = bands.fairness || "N/A";
-  qs("band-sentiment").textContent = bands.sentiment || "N/A";
-  qs("band-rigor").textContent = bands.rigor || "N/A";
-  qs("band-speed").textContent = bands.speed || "N/A";
-  qs("band-clarity").textContent = bands.clarity || "N/A";
-  qs("band-trust").textContent = bands.trust || "N/A";
 
-  // Heatmap now rendered lazily when heatmap tab first viewed.
+  requestAnimationFrame(() => {
+    const resultsView = document.getElementById("results-view");
+    resultsView?.scrollIntoView({ behavior: "smooth", block: "start" });
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  });
+
   showResultsTab("summary");
 
-  // Quality badge integration
-  try {
-    const qBlock = qs("quality-block");
-    if (qBlock && data.quality_score !== undefined) {
-      qBlock.hidden = false;
-      const badge = qs("quality-badge");
-      const elig = qs("incentive-eligibility");
-      const flagsEl = qs("quality-flags");
-      const score = data.quality_score;
-      let cls = "";
-      if (score < 0.55) cls = "risk";
-      else if (score < 0.75) cls = "warn";
-      if (badge) {
-        badge.className = "quality-badge " + cls;
-        // Ensure structure: <svg><use></use></svg> <span class="qb-text">...</span>
-        let svg = badge.querySelector("svg");
-        if (!svg) {
-          svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-          svg.setAttribute("width", "14");
-          svg.setAttribute("height", "14");
-          svg.setAttribute("aria-hidden", "true");
-          const use = document.createElementNS(
-            "http://www.w3.org/2000/svg",
-            "use"
-          );
-          svg.appendChild(use);
-          badge.prepend(svg);
-        }
-        const useEl = svg.querySelector("use");
-        const icon =
-          cls === "risk"
-            ? "#icon-risk"
-            : cls === "warn"
-              ? "#icon-warn"
-              : "#icon-check";
-        if (useEl) useEl.setAttribute("href", icon);
-        let textSpan = badge.querySelector(".qb-text");
-        if (!textSpan) {
-          textSpan = document.createElement("span");
-          textSpan.className = "qb-text";
-          badge.appendChild(textSpan);
-        }
-        textSpan.textContent = `Quality: ${(score * 100).toFixed(0)}%`;
-        // Build tooltip with core heuristics if provided
-        const q = data.quality || {};
-        const tipParts = [];
-        if (typeof q.diversity === "number")
-          tipParts.push(`Diversity ${(q.diversity * 100).toFixed(0)}%`);
-        if (typeof q.longest_run === "number")
-          tipParts.push(`Longest Run ${q.longest_run}`);
-        if (typeof q.non_lexical_ratio === "number")
-          tipParts.push(`Non-lex ${(q.non_lexical_ratio * 100).toFixed(0)}%`);
-        if (typeof q.gibberish_score === "number")
-          tipParts.push(`Gibberish ${(q.gibberish_score * 100).toFixed(0)}%`);
-        if (typeof q.common_word_ratio === "number")
-          tipParts.push(`Common ${(q.common_word_ratio * 100).toFixed(0)}%`);
-        if (typeof q.entropy === "number")
-          tipParts.push(`Entropy ${q.entropy.toFixed(2)}`);
-        badge.title = "Quality Heuristics: " + tipParts.join(" • ");
-        badge.setAttribute("aria-label", badge.title);
-      }
-      if (flagsEl) {
-        const fl = data.quality_flags || [];
-        flagsEl.textContent = fl.length ? "Flags: " + fl.join(", ") : "";
-      }
-      if (elig) {
-        const eligible = !!data.incentive_eligible;
-        elig.textContent = eligible
-          ? "Eligible for eGift"
-          : "Ineligible (low-effort detected)";
-        elig.style.color = eligible ? "#34d399" : "#f87171";
-        elig.title = eligible
-          ? "Submission passes quality heuristics"
-          : "Submission failed one or more heuristics (e.g. repetition, low diversity, gibberish) and is excluded from incentive.";
-      }
-    }
-  } catch (e) {
-    // ignore quality rendering errors
+  const submission = window.__lastSubmission || {};
+  const bands = data.bands || {};
+  const compositeIndex = Number(data.composite_index || 0);
+  const textScore = Number(data.diagnostics?.textScore ?? 0.6);
+  const qualityScore = Number(data.quality_score ?? 0);
+  const attentionRaw = Number(submission.attention ?? 0);
+  const nss = Number(((textScore - 0.5) * 2).toFixed(2));
+
+  window.__lastResult = { ...data, nss };
+  window.CXI_LAST_INDEX = compositeIndex;
+
+  animateNumber(document.getElementById("orb-score"), {
+    from: 0,
+    to: compositeIndex * 100,
+    duration: 1200,
+    decimals: 0,
+  });
+  const orbBand = document.getElementById("orb-band-label");
+  if (orbBand) orbBand.textContent = bands.overall || "Success";
+
+  animateNumber(document.getElementById("nss-display"), {
+    from: 0,
+    to: nss,
+    duration: 1000,
+    decimals: 2,
+    prefix: nss >= 0 ? "+" : "",
+  });
+  setBandIndicator(
+    document.getElementById("nss-band"),
+    bands.sentiment || (nss >= 0 ? "Positive" : "Needs Work"),
+  );
+
+  animateNumber(document.getElementById("quality-score"), {
+    from: 0,
+    to: qualityScore * 100,
+    decimals: 0,
+    suffix: "%",
+  });
+  const qualityLabel =
+    qualityScore >= 0.75 ? "Eligible" : qualityScore >= 0.55 ? "Caution" : "Risk";
+  setBandIndicator(document.getElementById("quality-band"), qualityLabel);
+
+  animateNumber(document.getElementById("attention-score"), {
+    from: 0,
+    to: attentionRaw,
+    decimals: 1,
+  });
+  const attentionLabel =
+    attentionRaw >= 4 ? "High" : attentionRaw >= 3 ? "Medium" : "Low";
+  setBandIndicator(document.getElementById("attention-band"), attentionLabel);
+
+  renderHighlights(submission.aspects || [], data.quality_flags || []);
+
+  const summaryText = buildSummaryText(
+    submission.stage,
+    nss,
+    submission.aspects || [],
+    bands.overall,
+  );
+  const summaryEl = document.getElementById("response-summary");
+  if (summaryEl) typewriter(summaryEl, summaryText, { delay: 16 });
+
+  const cueText = buildCoachingCue(submission.aspects || [], submission.stage);
+  const cueEl = document.getElementById("coaching-cue");
+  if (cueEl) typewriter(cueEl, cueText, { delay: 20 });
+
+  renderTranscriptPlayback(
+    [submission.well, submission.better, submission.rant]
+      .filter(Boolean)
+      .join(" "),
+  );
+
+  const revealSentence =
+    (submission.rant || "").trim() ||
+    (submission.well || "").trim() ||
+    (submission.better || "").trim() ||
+    "";
+  triggerScoreReveal({
+    stage: submission.stage,
+    band: bands.overall,
+    index: compositeIndex,
+    nss,
+    quality: qualityScore,
+    summary: summaryText,
+    aspects: submission.aspects || [],
+    sentence: revealSentence,
+  });
+
+  updateQualityBlock(data);
+
+  const heatmap = synthesizeHeatmapMatrix(
+    compositeIndex,
+    textScore,
+    submission,
+  );
+  applyHeatmapMatrix(heatmap);
+  window.__lastResult.heatmap = heatmap;
+  ensureDashboard().then(() => {
+    window.updateRosterHighlight?.();
+  });
+}
+
+function setBandIndicator(element, label = "") {
+  if (!element) return;
+  element.classList.remove("band-success", "band-caution", "band-risk");
+  const lower = label.toLowerCase();
+  const cls = lower.includes("risk")
+    ? "band-risk"
+    : lower.includes("caution") || lower.includes("medium") || lower.includes("later")
+      ? "band-caution"
+      : "band-success";
+  element.classList.add(cls);
+  element.textContent = label;
+}
+
+function renderHighlights(aspects, flags) {
+  const highlightEl = document.getElementById("highlights-display");
+  const absaEl = document.getElementById("absa-display");
+  const items = Array.isArray(aspects) && aspects.length ? aspects : ["responsiveness", "clarity"];
+  if (highlightEl) {
+    highlightEl.innerHTML = items
+      .slice(0, 4)
+      .map((aspect) => {
+        const tone = aspect.includes("feedback") || flags.length ? "negative" : "positive";
+        return `<span class="highlight-item highlight-${tone}">${formatAspect(aspect)}</span>`;
+      })
+      .join("");
+  }
+  if (absaEl) {
+    absaEl.innerHTML = items
+      .slice(0, 5)
+      .map((aspect) => {
+        const tone = aspect.includes("feedback") ? "negative" : "positive";
+        return `<span class="absa-tag absa-${tone}">${formatAspect(aspect)}</span>`;
+      })
+      .join("");
   }
 }
 
-// Expose for legacy inline script references (until full cleanup complete)
+function buildSummaryText(stage, nss, aspects, band) {
+  const stageLabel = formatStage(stage);
+  const sentiment = band ? band.toLowerCase() : nss >= 0 ? "positive" : "risk";
+  const strengths = aspects.slice(0, 2).map(formatAspect);
+  const focus = aspects[2] ? formatAspect(aspects[2]) : "feedback cadence";
+  const strengthLabel = strengths.length ? strengths.join(" & ") : "responsiveness";
+  return `Candidate sentiment landed ${sentiment} at the ${stageLabel} stage. Strengths: ${strengthLabel}. Focus next: ${focus}.`;
+}
+
+function buildCoachingCue(aspects, stage) {
+  const focus = aspects.find((a) => a.includes("feedback")) || aspects[0] || "follow-up clarity";
+  const stageLabel = formatStage(stage);
+  return `Coach the ${stageLabel.toLowerCase()} crew on ${formatAspect(
+    focus,
+  )} and ship a follow-up within 24 hours.`;
+}
+
+function renderTranscriptPlayback(text) {
+  const target = document.getElementById("transcript-playback");
+  if (!target) return;
+  clearTimeout(target.__transcriptTimer);
+  const cleaned = text.trim();
+  if (!cleaned) {
+    target.textContent = "Transcript playback will appear here once scored.";
+    return;
+  }
+  const tokens = cleaned.split(/\s+/);
+  target.innerHTML = tokens
+    .map((word, idx) => `<span data-idx="${idx}">${word}</span>`)
+    .join(" ");
+  let index = 0;
+  const step = () => {
+    const prev = target.querySelector("span.active");
+    if (prev) prev.classList.remove("active");
+    const next = target.querySelector(`span[data-idx="${index}"]`);
+    if (next) {
+      next.classList.add("active");
+      next.scrollIntoView({ block: "nearest", inline: "center" });
+    }
+    index = (index + 1) % tokens.length;
+    target.__transcriptTimer = setTimeout(step, 240);
+  };
+  target.__transcriptTimer = setTimeout(step, 320);
+}
+
+function updateQualityBlock(data) {
+  try {
+    const qBlock = qs("quality-block");
+    if (!qBlock || data.quality_score === undefined) return;
+    qBlock.hidden = false;
+    const badge = qs("quality-badge");
+    const elig = qs("incentive-eligibility");
+    const flagsEl = qs("quality-flags");
+    const score = data.quality_score;
+    let cls = "";
+    if (score < 0.55) cls = "risk";
+    else if (score < 0.75) cls = "warn";
+    if (badge) {
+      badge.className = "quality-badge " + cls;
+      let svg = badge.querySelector("svg");
+      if (!svg) {
+        svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        svg.setAttribute("width", "14");
+        svg.setAttribute("height", "14");
+        svg.setAttribute("aria-hidden", "true");
+        const use = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        svg.appendChild(use);
+        badge.prepend(svg);
+      }
+      const useEl = svg.querySelector("use");
+      const icon =
+        cls === "risk"
+          ? "#icon-risk"
+          : cls === "warn"
+            ? "#icon-warn"
+            : "#icon-check";
+      if (useEl) useEl.setAttribute("href", icon);
+      let textSpan = badge.querySelector(".qb-text");
+      if (!textSpan) {
+        textSpan = document.createElement("span");
+        textSpan.className = "qb-text";
+        badge.appendChild(textSpan);
+      }
+      textSpan.textContent = `Quality: ${(score * 100).toFixed(0)}%`;
+    }
+    if (flagsEl) {
+      const fl = data.quality_flags || [];
+      flagsEl.textContent = fl.length ? `Flags: ${fl.join(", ")}` : "";
+    }
+    if (elig) {
+      const eligible = !!data.incentive_eligible;
+      elig.textContent = eligible
+        ? "Eligible for eGift"
+        : "Ineligible (low-effort detected)";
+      elig.style.color = eligible ? "#34d399" : "#f87171";
+    }
+  } catch (err) {
+    console.warn("quality block render error", err);
+  }
+}
+
+function synthesizeHeatmapMatrix(index, textScore, submission) {
+  const stages = [
+    "applied",
+    "recruiter",
+    "hiring_manager",
+    "panel",
+    "assignment",
+    "offer",
+    "rejected",
+  ];
+  const aspects = ["communication", "scheduling", "clarity", "respect", "feedback"];
+  const token = window.CANDIDATE_TOKEN || "seed";
+  const activeStage = submission.stage;
+  const matrix = {};
+  aspects.forEach((aspect, aIdx) => {
+    matrix[aspect] = {};
+    stages.forEach((stage, sIdx) => {
+      const noise = seededRandom(token, `${aspect}:${stage}`) - 0.5;
+      let value = index - 0.4 + noise * 0.6;
+      if (stage === activeStage) value += 0.12;
+      if (aspect === "feedback") value += (textScore - 0.5) * 0.5;
+      if (aspect === "respect") value += 0.05;
+      value += (aIdx - 2) * 0.03 + (sIdx - 3) * 0.015;
+      value = Math.max(-0.9, Math.min(0.9, value));
+      matrix[aspect][stage] = Number(value.toFixed(2));
+    });
+  });
+  return matrix;
+}
+
+function applyHeatmapMatrix(matrix) {
+  document
+    .querySelectorAll(".heatmap-cell[data-aspect]")
+    .forEach((cell) => {
+      const aspect = cell.dataset.aspect;
+      const stage = cell.dataset.stage;
+      const value = matrix?.[aspect]?.[stage];
+      if (typeof value !== "number") return;
+      const formatted = value >= 0 ? `+${value.toFixed(1)}` : value.toFixed(1);
+      cell.textContent = formatted;
+      cell.classList.remove(
+        "heatmap-positive",
+        "heatmap-negative",
+        "heatmap-neutral",
+      );
+      const cls =
+        value > 0.15
+          ? "heatmap-positive"
+          : value < -0.15
+            ? "heatmap-negative"
+            : "heatmap-neutral";
+      cell.classList.add(cls);
+    });
+}
+
+function formatStage(stage) {
+  const map = {
+    applied: "Applied",
+    recruiter: "Recruiter Screen",
+    hiring_manager: "Hiring Manager",
+    panel: "Panel",
+    assignment: "Take-home",
+    offer: "Offer",
+    rejected: "Closure",
+  };
+  return map[stage] || "Panel";
+}
+
+function formatAspect(aspect) {
+  return (aspect || "")
+    .replace(/[_-]/g, " ")
+    .replace(/\b\w/g, (m) => m.toUpperCase())
+    .trim();
+}
 window.displayResults = displayResults;
 
 function wireTabs() {
@@ -279,6 +704,8 @@ function init() {
   wireTabs();
   wireDLQButtons();
   wireMisc();
+  setupInstructionPlacard();
+  setupScoreReveal();
   restorePanels();
   performanceMark("app_init_end");
   // Auto-load panel metrics after idle

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,17 +1,470 @@
-// Dashboard export and visualization functions
+const stageLabels = {
+  applied: "Applied",
+  recruiter: "Recruiter Screen",
+  hiring_manager: "Hiring Manager",
+  panel: "Panel Interview",
+  assignment: "Take-home",
+  offer: "Offer",
+  rejected: "Closure",
+};
 
-export function exportData() {
-  console.log('Data export triggered');
+const roster = [
+  { name: "Jason R.", goal: "SLA < 48 hours feedback." },
+  {
+    name: "Jess D.",
+    goal: "Clarify interview agenda and the role every time.",
+  },
+  {
+    name: "Priya K.",
+    goal: "Ship technical debriefs with action-ready notes.",
+  },
+  {
+    name: "Amelia S.",
+    goal: "Walk candidates through the rubric before questions start.",
+  },
+];
+
+const aspectPlaybook = {
+  communication: {
+    headline: "Tighten interview communication loops",
+    action:
+      "Share the interview outline before each call and recap decisions in writing within 24 hours.",
+  },
+  clarity: {
+    headline: "Level-set expectations on scope",
+    action:
+      "Align interviewers on what “great” looks like and provide concrete examples when answering role questions.",
+  },
+  feedback: {
+    headline: "Accelerate candidate feedback",
+    action:
+      "Commit to a 48-hour feedback SLA and template the debrief so panelists can add signal quickly.",
+  },
+  respect: {
+    headline: "Reinforce candidate-first etiquette",
+    action:
+      "Remind panelists to pause, let the candidate finish, and thank them for their time explicitly.",
+  },
+  scheduling: {
+    headline: "Smooth out the scheduling path",
+    action:
+      "Centralize interviewer availability and send consolidated invites with buffers for prep.",
+  },
+};
+
+const shareTemplates = {
+  email: (ctx, tasks) => `Subject: CXI coaching plan for ${ctx.stageLabel}
+
+Hi team,
+
+${ctx.summary}
+\nKey coaching moves:\n${tasks
+    .map((task) => `• ${task.headline} — ${task.action}`)
+    .join("\n")}\n\nLet’s close the loop by ${ctx.deadlineLabel}.`,
+  slack: (ctx, tasks) => `:sparkles: CXI pulse for ${ctx.stageLabel}\n${ctx.summary}\n${tasks
+    .map((task) => `• *${task.headline}* — ${task.action}`)
+    .join("\n")}\n${ctx.deadlineLabel}`,
+  teams: (ctx, tasks) => `CXI dashboard sync (${ctx.stageLabel})\n${ctx.summary}\nAction queue:\n${tasks
+    .map((task) => `• ${task.headline} — ${task.action}`)
+    .join("\n")}\nReply here with owners by ${ctx.deadlineLabel}.`,
+  pdf: (ctx, tasks) => `CXI Coaching Brief\nStage: ${ctx.stageLabel}\nNSS: ${ctx.nss.toFixed(2)}\nComposite Index: ${(ctx.index * 100).toFixed(0)}\n\nSummary\n${ctx.summary}\n\nCoaching Plan\n${tasks
+    .map((task, idx) => `${idx + 1}. ${task.headline}\n   ${task.action}`)
+    .join("\n")}\n\nDistribution List\n${roster.map((r) => `${r.name} — ${r.goal}`).join("\n")}`,
+};
+
+const aspectKeywords = {
+  communication: ["communicat", "explain", "responsive", "tone"],
+  clarity: ["clear", "clarity", "understand", "expect"],
+  feedback: ["feedback", "follow", "response", "update"],
+  respect: ["respect", "kind", "rude", "courteous"],
+  scheduling: ["schedule", "reschedule", "calendar", "timing"],
+};
+
+const timeframeMinutes = {
+  "7d": 7 * 24 * 60,
+  "30d": 30 * 24 * 60,
+  "90d": 90 * 24 * 60,
+};
+
+let modalOverlay;
+let checklistEl;
+let summaryEl;
+let sharePreviewEl;
+let currentTasks = [];
+let lastContext = null;
+
+function getToast() {
+  return window.__cxToast || window.showToast || null;
 }
 
-export function showHeatmapDetail(data) {
-  console.log('Heatmap detail:', data);
+function formatAspect(value = "") {
+  return value
+    .replace(/[_-]/g, " ")
+    .replace(/\b\w/g, (m) => m.toUpperCase())
+    .trim();
 }
 
-export function filterTasks(filter) {
-  console.log('Tasks filtered:', filter);
+function formatPriority(nss = 0, index = 0.6) {
+  if (nss < 0 || index < 0.5) return "high";
+  if (nss < 0.3 || index < 0.65) return "medium";
+  return "low";
 }
 
-export function pushToDashboard(data) {
-  console.log('Data pushed to dashboard:', data);
+function ensureModalBound() {
+  if (modalOverlay) return;
+  modalOverlay = document.getElementById("dashboard-modal");
+  checklistEl = document.getElementById("dashboard-task-list");
+  summaryEl = document.getElementById("dashboard-modal-summary");
+  sharePreviewEl = document.getElementById("share-preview");
+  if (!modalOverlay) return;
+
+  modalOverlay.addEventListener("click", (evt) => {
+    if (evt.target === modalOverlay) {
+      closeModal();
+    }
+  });
+  modalOverlay
+    .querySelectorAll("[data-close-dashboard]")
+    .forEach((btn) => btn.addEventListener("click", closeModal));
+  const shareButtons = modalOverlay.querySelectorAll("[data-share]");
+  shareButtons.forEach((btn) =>
+    btn.addEventListener("click", () => handleShare(btn.dataset.share)),
+  );
+  const copyBtn = modalOverlay.querySelector('[data-action="copy-checklist"]');
+  copyBtn?.addEventListener("click", copySelectedTasks);
 }
+
+function openModal() {
+  ensureModalBound();
+  if (!modalOverlay) return;
+  modalOverlay.hidden = false;
+  requestAnimationFrame(() => {
+    modalOverlay.classList.add("visible");
+  });
+}
+
+function closeModal() {
+  if (!modalOverlay) return;
+  modalOverlay.classList.remove("visible");
+  setTimeout(() => {
+    modalOverlay.hidden = true;
+    if (sharePreviewEl) {
+      sharePreviewEl.hidden = true;
+      sharePreviewEl.textContent = "";
+    }
+  }, 180);
+}
+
+function gatherContext() {
+  const submission = window.__lastSubmission || {};
+  const result = window.__lastResult || {};
+  const summary =
+    document.getElementById("response-summary")?.textContent.trim() ||
+    "Latest candidate feedback captured.";
+  const stage = submission.stage || "panel";
+  const index = Number(result.composite_index || 0.62);
+  const nss = Number(result.nss ?? 0.4);
+  const stageLabel = stageLabels[stage] || formatAspect(stage);
+  const aspects = Array.isArray(submission.aspects) && submission.aspects.length
+    ? submission.aspects
+    : ["communication", "feedback", "clarity"];
+  const deadlineLabel = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(Date.now() + 36 * 3600 * 1000);
+  return {
+    submission,
+    result,
+    summary,
+    stage,
+    stageLabel,
+    aspects,
+    index,
+    nss,
+    deadlineLabel,
+  };
+}
+
+function buildTasks(ctx) {
+  const priority = formatPriority(ctx.nss, ctx.index);
+  return ctx.aspects.slice(0, 3).map((aspect, idx) => {
+    const play = aspectPlaybook[aspect] || {
+      headline: `Improve ${formatAspect(aspect)}`,
+      action: `Run a coaching huddle focused on ${formatAspect(aspect)} and capture one measurable improvement.`,
+    };
+    const owner = roster[idx % roster.length];
+    return {
+      id: `task-${Date.now()}-${idx}`,
+      aspect,
+      headline: play.headline,
+      action: play.action,
+      owner,
+      priority: idx === 0 ? priority : idx === 1 ? "medium" : "low",
+    };
+  });
+}
+
+function renderChecklist(tasks, ctx) {
+  if (!checklistEl) return;
+  checklistEl.innerHTML = "";
+  tasks.forEach((task) => {
+    const item = document.createElement("label");
+    item.className = "checklist-item";
+    item.innerHTML = `
+      <input type="checkbox" data-task-id="${task.id}" checked />
+      <span>
+        <strong>${task.headline}</strong>
+        <em>${task.action}</em>
+        <small>Owner: ${task.owner.name} · ${task.owner.goal}</small>
+        <span class="chip chip-${task.priority}">${formatAspect(task.priority)} priority</span>
+      </span>
+    `;
+    checklistEl.appendChild(item);
+  });
+  if (summaryEl) {
+    summaryEl.textContent = `${tasks.length} coaching task${
+      tasks.length === 1 ? "" : "s"
+    } queued for ${ctx.stageLabel}.`;
+  }
+}
+
+function copySelectedTasks() {
+  if (!checklistEl) return;
+  const selectedIds = Array.from(
+    checklistEl.querySelectorAll('input[type="checkbox"]:checked'),
+  ).map((input) => input.dataset.taskId);
+  const tasks = currentTasks.filter((task) => selectedIds.includes(task.id));
+  if (!tasks.length) {
+    getToast()?.("Select at least one task to copy.", "warning");
+    return;
+  }
+  const payload = tasks
+    .map(
+      (task, idx) =>
+        `${idx + 1}. ${task.headline}\n   ${task.action}\n   Owner: ${task.owner.name} (${task.owner.goal})`,
+    )
+    .join("\n\n");
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(payload).then(
+      () => getToast()?.("Coaching tasks copied to clipboard.", "positive"),
+      () => getToast()?.("Clipboard copy unavailable in this browser.", "warning"),
+    );
+  } else {
+    getToast()?.("Clipboard access unavailable; select text manually.", "warning");
+  }
+}
+
+function handleShare(channel) {
+  if (!sharePreviewEl) return;
+  const template = shareTemplates[channel];
+  if (!template) return;
+  const preview = template(lastContext, currentTasks);
+  sharePreviewEl.hidden = false;
+  sharePreviewEl.textContent = preview;
+  sharePreviewEl.dataset.channel = channel;
+  const toastTone = channel === "email" || channel === "pdf" ? "positive" : "warning";
+  getToast()?.(`Preview ready for ${channel.toUpperCase()}.`, toastTone);
+}
+
+function highlightCell(aspect, stage) {
+  document
+    .querySelectorAll(".heatmap-cell.active")
+    .forEach((cell) => cell.classList.remove("active"));
+  const cell = document.querySelector(
+    `.heatmap-cell[data-aspect="${aspect}"][data-stage="${stage}"]`,
+  );
+  cell?.classList.add("active");
+}
+
+function extractEvidence(aspect) {
+  const submission = window.__lastSubmission || {};
+  const text = [submission.well, submission.better, submission.rant]
+    .filter(Boolean)
+    .join(" ");
+  if (!text) {
+    return [
+      "No transcript captured yet — once feedback is submitted, NSS will surface exact highlights.",
+    ];
+  }
+  const keywords = aspectKeywords[aspect] || [aspect];
+  const sentences = text.split(/(?<=[.!?])\s+/);
+  const matches = [];
+  sentences.forEach((sentence) => {
+    const lower = sentence.toLowerCase();
+    if (keywords.some((kw) => lower.includes(kw))) {
+      let highlighted = sentence;
+      keywords.forEach((kw) => {
+        const reg = new RegExp(`(${kw})`, "gi");
+        highlighted = highlighted.replace(reg, '<mark>$1</mark>');
+      });
+      matches.push(highlighted);
+    }
+  });
+  if (!matches.length) {
+    const first = sentences[0] || text;
+    return [first];
+  }
+  return matches.slice(0, 3);
+}
+
+function renderHeatmapDetail(aspect, stage) {
+  const detailEl = document.getElementById("heatmap-detail");
+  const titleEl = document.getElementById("detail-title");
+  const contentEl = document.getElementById("detail-content");
+  if (!detailEl || !titleEl || !contentEl) return;
+  highlightCell(aspect, stage);
+
+  const matrix = window.__lastResult?.heatmap || {};
+  const value = matrix?.[aspect]?.[stage];
+  const score = typeof value === "number" ? value : 0;
+  const ctx = gatherContext();
+  const evidence = extractEvidence(aspect);
+  const stageLabel = stageLabels[stage] || formatAspect(stage);
+  titleEl.textContent = `${formatAspect(aspect)} × ${stageLabel}`;
+  const tone = score > 0.15 ? "positive" : score < -0.15 ? "negative" : "neutral";
+  const formattedScore = `${score >= 0 ? "+" : ""}${score.toFixed(2)}`;
+  contentEl.innerHTML = `
+    <div class="score-pill score-${tone}">Sentiment ${formattedScore}</div>
+    <p class="mt-6">${aspectPlaybook[aspect]?.headline ||
+      `Focus on ${formatAspect(aspect)} to lift ${stageLabel}.`}</p>
+    <div class="mt-6"><strong>In their words:</strong></div>
+    <ul class="mt-025 insight-list">
+      ${evidence.map((line) => `<li>${line}</li>`).join("")}
+    </ul>
+    <div class="mt-6"><strong>Next coaching move:</strong></div>
+    <p>${aspectPlaybook[aspect]?.action ||
+      "Review transcripts and capture a coaching follow-up."}</p>
+    <div class="mt-8">
+      <button class="btn btn-primary" data-action="push-dashboard">Queue task for ${stageLabel}</button>
+    </div>
+  `;
+  contentEl
+    .querySelector('[data-action="push-dashboard"]')
+    ?.addEventListener("click", (event) => {
+      event.preventDefault();
+      pushToDashboard();
+    });
+  detailEl.classList.remove("hidden");
+  detailEl.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+function updateTaskHeader() {
+  const container = document.querySelector(".task-header");
+  if (!container) return;
+  const visible = Array.from(document.querySelectorAll(".task-item")).filter(
+    (item) => item.style.display !== "none",
+  );
+  container.textContent = `Active Tasks (${visible.length})`;
+}
+
+export function exportData(format = "json") {
+  ensureModalBound();
+  const previewEl = document.getElementById("export-preview");
+  const contentEl = document.getElementById("export-content");
+  if (!previewEl || !contentEl) return;
+  const ctx = gatherContext();
+  const payload = {
+    timestamp: new Date().toISOString(),
+    nss: ctx.nss,
+    composite_index: ctx.index,
+    stage: ctx.stage,
+    summary: ctx.summary,
+    coaching_cue:
+      document.getElementById("coaching-cue")?.textContent.trim() ||
+      "Coach interview team on timely follow-ups.",
+  };
+  let preview = "";
+  switch (format) {
+    case "json":
+      preview = JSON.stringify(payload, null, 2);
+      break;
+    case "csv":
+      preview = `timestamp,nss,index,stage,summary,coaching\n"${payload.timestamp}",${payload.nss.toFixed(
+        2,
+      )},${(payload.composite_index * 100).toFixed(0)},${payload.stage},"${payload.summary}","${payload.coaching_cue}"`;
+      break;
+    case "pdf":
+      preview = shareTemplates.pdf(ctx, buildTasks(ctx));
+      break;
+    case "summary":
+    default:
+      preview = `${ctx.summary}\n\nNSS: ${ctx.nss.toFixed(2)}\nComposite Index: ${(ctx.index * 100).toFixed(0)}\nCoaching: ${payload.coaching_cue}`;
+      break;
+  }
+  previewEl.hidden = false;
+  contentEl.textContent = preview;
+  getToast()?.(`Preview ready for ${format.toUpperCase()}.`, "positive");
+}
+
+export function showHeatmapDetail(aspect, stage) {
+  ensureModalBound();
+  renderHeatmapDetail(aspect, stage);
+}
+
+export function filterTasks() {
+  const stageFilter = document.getElementById("stage-filter")?.value || "";
+  const priorityFilter = document.getElementById("priority-filter")?.value || "";
+  const timeframeFilter = document.getElementById("timeframe-filter")?.value || "30d";
+  const maxAge = timeframeMinutes[timeframeFilter] || timeframeMinutes["30d"];
+  const now = Date.now();
+  const items = document.querySelectorAll(".task-item");
+  let visibleCount = 0;
+  items.forEach((item) => {
+    const stage = item.dataset.stage || "";
+    const priority = item.dataset.priority || "";
+    const created = Number(item.dataset.createdAt || 0);
+    const ageMinutes = created ? (now - created) / 60000 : Number(item.dataset.ageMinutes || 0);
+    const matchesStage = !stageFilter || stage === stageFilter;
+    const matchesPriority = !priorityFilter || priority === priorityFilter;
+    const matchesTimeframe = !maxAge || ageMinutes <= maxAge;
+    if (matchesStage && matchesPriority && matchesTimeframe) {
+      item.style.display = "block";
+      visibleCount += 1;
+    } else {
+      item.style.display = "none";
+    }
+  });
+  const header = document.querySelector(".task-header");
+  if (header) header.textContent = `Active Tasks (${visibleCount})`;
+}
+
+export function pushToDashboard() {
+  ensureModalBound();
+  if (!modalOverlay) return;
+  const ctx = gatherContext();
+  lastContext = ctx;
+  currentTasks = buildTasks(ctx);
+  renderChecklist(currentTasks, ctx);
+  openModal();
+  handleShare("email");
+  getToast()?.("Coaching plan staged in dashboard.", "positive");
+}
+
+export function pushToDashboardSilent(task) {
+  currentTasks = buildTasks(task || gatherContext());
+}
+
+export function showHeatmapDetailFromCell(aspect, stage) {
+  showHeatmapDetail(aspect, stage);
+}
+
+// Initialize filters on load
+if (document.readyState === "complete") {
+  filterTasks();
+} else {
+  window.addEventListener("load", () => filterTasks());
+}
+
+export function updateRosterHighlight() {
+  const rosterEl = document.getElementById("interviewer-roster");
+  if (!rosterEl) return;
+  rosterEl.classList.add("pulse");
+  setTimeout(() => rosterEl.classList.remove("pulse"), 1200);
+}
+
+export default {
+  exportData,
+  showHeatmapDetail,
+  filterTasks,
+  pushToDashboard,
+};

--- a/js/invite.js
+++ b/js/invite.js
@@ -1,21 +1,172 @@
-// Survey invitation and modal functionality
-
 const inlineOpenInvite =
   typeof window !== "undefined" && typeof window.openInvite === "function"
     ? window.openInvite
     : null;
 
+const toast = () => window.__cxToast || window.showToast || null;
+
+const stageLabels = {
+  applied: "Applied",
+  recruiter: "Recruiter Screen",
+  hiring_manager: "Hiring Manager",
+  panel: "Panel Interview",
+  assignment: "Take-home",
+  offer: "Offer",
+  rejected: "Closure",
+};
+
+function formatAspect(value = "") {
+  return value
+    .replace(/[_-]/g, " ")
+    .replace(/\b\w/g, (m) => m.toUpperCase())
+    .trim();
+}
+
+function derivePriority(index = 0.6, nss = 0.3) {
+  if (nss < 0 || index < 0.5) return "high";
+  if (nss < 0.35 || index < 0.65) return "medium";
+  return "low";
+}
+
+function ensureTaskHeader() {
+  const header = document.querySelector(".task-header");
+  if (!header) return;
+  const visible = Array.from(document.querySelectorAll(".task-item"))
+    .filter((item) => item.style.display !== "none")
+    .length;
+  header.textContent = `Active Tasks (${visible})`;
+}
+
+function createTaskCard({
+  stage,
+  aspects,
+  index,
+  priority,
+  createdAt,
+  nss,
+  cue,
+}) {
+  const container = document.getElementById("task-list");
+  if (!container) return null;
+  const card = document.createElement("div");
+  card.className = "task-item";
+  card.dataset.stage = stage;
+  card.dataset.priority = priority;
+  card.dataset.createdAt = createdAt;
+  card.dataset.ageMinutes = Math.max(
+    0,
+    Math.round((Date.now() - createdAt) / 60000),
+  );
+  const stageLabel = stageLabels[stage] || formatAspect(stage);
+  const aspectTags = (aspects || [])
+    .map((a) => `<span class="tag">${formatAspect(a)}</span>`)
+    .join(" ");
+  const priorityLabel = priority.charAt(0).toUpperCase() + priority.slice(1);
+  const diffMinutes = Math.max(1, Math.round((Date.now() - createdAt) / 60000));
+  const relFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  const ageLabel =
+    diffMinutes < 60
+      ? relFormatter.format(-diffMinutes, "minute")
+      : relFormatter.format(-Math.round(diffMinutes / 60), "hour");
+  card.innerHTML = `
+    <div class="task-meta">
+      <div>
+        <span class="task-priority priority-${priority}">${priorityLabel}</span>
+        <span class="muted ml-1">${stageLabel} • ${ageLabel}</span>
+      </div>
+      <div class="muted small">NSS: ${nss >= 0 ? "+" : ""}${nss.toFixed(2)}</div>
+    </div>
+    <div class="task-coaching">${cue}</div>
+    <div class="task-details">Aspects: ${aspectTags || "–"} • Index: ${(index * 100).toFixed(
+    0,
+  )}</div>
+  `;
+  container.prepend(card);
+  return card;
+}
+
+function appendTaskRow({ stage, aspects, index, priority, createdAt, nss, cue }) {
+  const tableBody = document.getElementById("task-rows");
+  if (!tableBody) return;
+  const row = document.createElement("tr");
+  const ts = new Date(createdAt);
+  row.innerHTML = `
+    <td>${ts.toLocaleString()}</td>
+    <td>${stageLabels[stage] || formatAspect(stage)}</td>
+    <td>${(aspects || [])
+      .map((aspect) => `<span class="tag">${formatAspect(aspect)}</span>`)
+      .join(" ")}</td>
+    <td><span class="priority-${priority}">${(index * 100).toFixed(0)}</span></td>
+  `;
+  tableBody.prepend(row);
+}
+
 export function openInvite(candidateToken = "", nudgeRound = 0) {
   if (typeof inlineOpenInvite === "function") {
     return inlineOpenInvite(candidateToken, nudgeRound);
   }
+  return null;
 }
 
-export function pushTaskRow(task) {
-  console.log('pushTaskRow:', task);
+export function pushTaskRow(task = {}) {
+  const submission = window.__lastSubmission || {};
+  const result = window.__lastResult || {};
+  const stage = task.stage || submission.stage || "panel";
+  const aspects = task.aspects && task.aspects.length ? task.aspects : submission.aspects || [];
+  const index =
+    typeof task.index === "number"
+      ? task.index
+      : typeof result.composite_index === "number"
+        ? result.composite_index
+        : 0.62;
+  const nss =
+    typeof task.nss === "number"
+      ? task.nss
+      : typeof result.nss === "number"
+        ? result.nss
+        : 0.32;
+  const cue =
+    task.cue ||
+    document.getElementById("coaching-cue")?.textContent ||
+    "Confirm follow-up SLAs and share the interview outline.";
+  const priority = task.priority || derivePriority(index, nss);
+  const createdAt = task.createdAt || Date.now();
+
+  createTaskCard({ stage, aspects, index, priority, createdAt, nss, cue });
+  appendTaskRow({ stage, aspects, index, priority, createdAt, nss, cue });
+  ensureTaskHeader();
+  window.filterTasks?.();
+  const notify = toast();
+  notify?.("Task queued for the hiring squad.", priority === "high" ? "warning" : "positive");
 }
 
-export function showATSWebhook() {
-  const panel = document.getElementById('ats-panel');
+export function showATSWebhook(stage, role, token) {
+  let debugMode = false;
+  try {
+    debugMode = new URL(location.href).searchParams.get("debug") === "1";
+  } catch (_) {
+    debugMode = false;
+  }
+  if (!debugMode) return;
+  const payload = {
+    event: "candidate_feedback_invite",
+    stage: stage || "panel",
+    role_family: role || "engineering",
+    candidate_token:
+      token ||
+      window.CANDIDATE_TOKEN ||
+      "anon_" + Math.random().toString(36).slice(2, 7),
+    sent_at: new Date().toISOString(),
+    source: new URL(location.href).searchParams.get("src") || null,
+  };
+  const panel = document.getElementById("ats-panel");
+  const json = document.getElementById("ats-json");
+  const stageEl = document.getElementById("ats-stage");
+  const roleEl = document.getElementById("ats-role");
+  const tokenEl = document.getElementById("ats-token");
+  if (stageEl) stageEl.textContent = payload.stage;
+  if (roleEl) roleEl.textContent = payload.role_family;
+  if (tokenEl) tokenEl.textContent = payload.candidate_token;
+  if (json) json.textContent = JSON.stringify(payload, null, 2);
   if (panel) panel.hidden = false;
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -29,3 +29,49 @@ export function debounce(func, wait) {
     timeout = setTimeout(later, wait);
   };
 }
+
+export function animateNumber(
+  element,
+  { from = 0, to = 0, duration = 800, decimals = 0, prefix = "", suffix = "" } = {}
+) {
+  if (!element) return;
+  const start = Number(from);
+  const end = Number(to);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    element.textContent = `${prefix}${end.toFixed?.(decimals) ?? end}${suffix}`;
+    return;
+  }
+  const delta = end - start;
+  const startTime = performance.now();
+  const easeOut = (t) => 1 - Math.pow(1 - t, 3);
+
+  function tick(now) {
+    const elapsed = Math.min(1, (now - startTime) / duration);
+    const eased = easeOut(elapsed);
+    const value = start + delta * eased;
+    element.textContent = `${prefix}${value.toFixed(decimals)}${suffix}`;
+    if (elapsed < 1) requestAnimationFrame(tick);
+  }
+
+  requestAnimationFrame(tick);
+}
+
+export async function typewriter(element, text, { delay = 22 } = {}) {
+  if (!element) return;
+  element.textContent = "";
+  for (const char of text.split("")) {
+    element.textContent += char;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+}
+
+export function seededRandom(seed = "", key = "") {
+  const str = `${seed}:${key}`;
+  let h = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    h = Math.imul(31, h) + str.charCodeAt(i);
+  }
+  const normalized = ((h >>> 0) % 10000) / 10000;
+  return normalized;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,36 @@
 /* Extracted styles from inline index.html for maintainability */
-:root { --primary:#667eea; --primary-dark:#5a6fd8; --cxi-amber:#667eea; --cxi-navy:#333333; --slate:#e9ecef; --success:#16a34a; --warning:#f59e0b; --risk:#f43f5e; --bg:#ffffff; --card:#ffffff; --text:#333333; --muted:rgba(0,0,0,0.6); --radius:12px; --shadow:0 10px 30px rgba(0,0,0,0.2); --gradient-app:linear-gradient(135deg,#667eea 0%,#764ba2 100%); --gradient-positive:linear-gradient(90deg,#22c55e,#84cc16); }
+:root {
+  --primary: #7c5cff;
+  --primary-dark: #6040f8;
+  --primary-soft: rgba(124, 92, 255, 0.18);
+  --cxi-amber: #f7b733;
+  --cxi-navy: #101631;
+  --slate: rgba(148, 163, 184, 0.28);
+  --success: #4ade80;
+  --warning: #facc15;
+  --risk: #fb7185;
+  --bg: #0c1224;
+  --card: rgba(14, 21, 41, 0.92);
+  --card-glass: rgba(20, 27, 51, 0.78);
+  --text: #f8fbff;
+  --muted: rgba(226, 232, 255, 0.72);
+  --radius: 16px;
+  --shadow: 0 24px 54px rgba(4, 11, 32, 0.55);
+  --shadow-soft: 0 14px 36px rgba(20, 28, 56, 0.55);
+  --gradient-app: radial-gradient(140% 120% at 10% 0%, #24153d 0%, #0d1630 38%, #050914 100%);
+  --gradient-results: linear-gradient(135deg, #3425a0 0%, #512d8d 38%, #12192f 100%);
+  --gradient-positive: linear-gradient(100deg, #10b981 0%, #22d3ee 100%);
+  --gradient-risk: linear-gradient(100deg, #fb7185 0%, #f97316 100%);
+  --heat-positive: rgba(34, 197, 94, 0.18);
+  --heat-negative: rgba(248, 113, 113, 0.22);
+  --heat-neutral: rgba(234, 179, 8, 0.18);
+  --font-display: "Inter", "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --blur-xl: blur(28px);
+}
 *{margin:0;padding:0;box-sizing:border-box;}
-body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--gradient-app);color:var(--text);overflow:hidden;}
-@media (prefers-reduced-motion:reduce){body{background:#667eea;}}
+body{font-family:var(--font-display);background:var(--gradient-app);color:var(--text);min-height:100vh;overflow-x:hidden;overflow-y:auto;transition:background .6s ease;}
+@media (prefers-reduced-motion:reduce){body{background:#101631;}}
 #hud-toggle-btn{position:fixed;top:8px;left:8px;z-index:9998;background:rgba(0,0,0,0.55);color:#fff;border:1px solid rgba(255,255,255,0.25);padding:6px 10px;font:12px system-ui,sans-serif;border-radius:6px;cursor:pointer;-webkit-backdrop-filter:blur(4px);backdrop-filter:blur(4px);transition:background .2s;}#hud-toggle-btn:hover{background:rgba(0,0,0,0.7);}
 .skip-link{position:absolute;left:-999px;top:8px;background:#111;color:#fff;padding:8px 12px;border-radius:6px;z-index:10000;}.skip-link:focus{left:8px;outline:2px solid #fff;}
 .invite-sub{margin:6px 0 10px;}
@@ -13,21 +41,24 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;b
 .export-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;}
 .export-pre{background:var(--bg);padding:1rem;border-radius:6px;overflow:auto;max-height:400px;}
 .countdown{font-weight:700;color:var(--primary);} .winmeter{background:#0a1b34;border:1px solid #1d3153;border-radius:10px;padding:10px;margin-top:10px;} .winmeter .bar{height:8px;background:#132440;border-radius:6px;overflow:hidden;margin-top:6px;} .winmeter .fill{height:100%;width:0%;background:var(--gradient-positive);transition:width .5s ease;}
-.interview-container{height:100vh;display:flex;flex-direction:column;background:transparent;}
-.cxi-meeting{background:#0b1220;border:1px solid #1c2334;border-radius:14px;overflow:hidden;position:relative;}
-.call-instructions{position:absolute;top:16px;left:16px;width:min(260px,92%);padding:16px 18px;border-radius:14px;border:1px solid rgba(148,163,184,0.35);background:rgba(15,23,42,0.9);color:#e6efff;box-shadow:0 18px 36px rgba(2,6,23,0.55);backdrop-filter:blur(6px);z-index:20;}
-.call-instructions .eyebrow{display:block;font-size:.68rem;letter-spacing:.18em;text-transform:uppercase;font-weight:700;margin-bottom:.35rem;color:#60a5fa;}
-.call-instructions h2{font-size:1rem;line-height:1.35;margin-bottom:.75rem;color:#f8fafc;}
-.call-instructions p{font-size:.84rem;line-height:1.4;color:rgba(226,232,255,0.92);margin-bottom:.5rem;}
-.call-instructions ul{margin:0;padding-left:1.1rem;display:grid;gap:.45rem;font-size:.78rem;color:rgba(226,232,255,0.82);text-align:left;}
+.interview-container{min-height:calc(100vh - 32px);display:flex;justify-content:center;align-items:center;padding:clamp(16px,3vw,48px);background:transparent;}
+.cxi-meeting{background:var(--card-glass);border:1px solid rgba(99,102,241,.28);border-radius:24px;overflow:hidden;position:relative;width:min(1120px,96vw);box-shadow:var(--shadow);backdrop-filter:blur(24px);}
+.call-instructions{position:absolute;top:20px;left:20px;width:min(300px,90%);padding:18px 20px 22px;border-radius:18px;border:1px solid rgba(148,163,184,.35);background:linear-gradient(145deg,rgba(14,21,41,.96),rgba(40,30,72,.88));color:#e6efff;box-shadow:0 18px 42px rgba(12,18,36,.75);backdrop-filter:blur(20px);z-index:24;transition:opacity .45s ease,transform .45s ease;}
+.call-instructions[data-hidden="true"]{opacity:0;transform:translateY(-12px) scale(.96);pointer-events:none;}
+.call-instructions[data-state="fading"]{opacity:.1;}
+.call-instructions .eyebrow{display:flex;align-items:center;gap:6px;font-size:.68rem;letter-spacing:.18em;text-transform:uppercase;font-weight:700;margin-bottom:.4rem;color:#7dd3fc;}
+.call-instructions .eyebrow::before{content:"";width:28px;height:1px;background:linear-gradient(90deg,transparent,rgba(125,211,252,.6));}
+.call-instructions h2{font-size:1.12rem;line-height:1.4;margin-bottom:.75rem;color:#f8fafc;}
+.call-instructions p{font-size:.88rem;line-height:1.48;color:rgba(226,232,255,.92);margin-bottom:.5rem;}
+.call-instructions ul{margin:0;padding-left:1.1rem;display:grid;gap:.45rem;font-size:.8rem;color:rgba(226,232,255,.82);text-align:left;}
 .call-instructions li strong{color:#facc15;font-weight:700;}
 .call-instructions footer{margin-top:.75rem;font-size:.72rem;color:rgba(148,163,184,0.9);}
-.cxi-topbar{display:flex;justify-content:space-between;align-items:center;padding:10px 12px;background:#0f172a;color:#dbe3f8;border-bottom:1px solid #1f2840;}
+.cxi-topbar{display:flex;justify-content:space-between;align-items:center;padding:14px 18px;background:rgba(12,17,38,.88);color:#dbe3f8;border-bottom:1px solid rgba(148,163,184,.16);}
 .cxi-topbar .left,.cxi-topbar .right{display:flex;align-items:center;gap:8px;}
 .cxi-topbar .dot{width:8px;height:8px;border-radius:999px;display:inline-block;} .cxi-topbar .dot.live{background:#f43f5e;box-shadow:0 0 0 6px rgba(244,63,94,0.15);} .cxi-topbar .chip{font-size:.78rem;padding:4px 8px;border-radius:999px;background:#0b1329;border:1px solid #243356;color:#aac0ee;} .cxi-topbar .topic{color:#b9c7ea;} .cxi-topbar .sep{color:#5b6c93;}
-.cxi-gallery{display:grid;grid-template-columns:repeat(2,1fr);gap:10px;padding:12px;background:#0b1220;} .cxi-gallery .tile{background:radial-gradient(120% 120% at 0% 0%,#19233c,#0e1528 70%);border:1px solid #1b2440;border-radius:12px;aspect-ratio:16/9;position:relative;} .cxi-gallery .badge{position:absolute;left:8px;bottom:8px;background:rgba(0,0,0,0.45);color:#e6edff;padding:4px 8px;border-radius:8px;font-size:.8rem;border:1px solid rgba(255,255,255,0.15);}
-.cxi-toolbar{display:flex;align-items:center;gap:8px;padding:10px;background:#0f172a;border-top:1px solid #1f2840;} .cxi-toolbar .ctrl{background:#101a33;color:#dbe3f8;border:1px solid #243356;padding:8px 12px;border-radius:10px;cursor:pointer;position:relative;} .cxi-toolbar .ctrl::after{content:"";position:absolute;inset:-4px;border-radius:12px;border:2px solid transparent;pointer-events:none;transition:border-color .12s ease,box-shadow .12s ease;} .cxi-toolbar .ctrl:hover{background:#132040;} .cxi-toolbar .ctrl:hover::after{border-color:rgba(96,165,250,0.35);box-shadow:0 0 0 2px rgba(37,99,235,0.2);} .cxi-toolbar .ctrl:focus-visible::after{border-color:rgba(96,165,250,0.75);box-shadow:0 0 0 3px rgba(37,99,235,0.35);} .cxi-toolbar .ctrl.leave{background:#2a0f14;border-color:#5a1b23;color:#fecaca;font-weight:700;} .cxi-toolbar .ctrl.leave:hover{background:#3a1218;box-shadow:0 12px 22px rgba(127,29,29,0.4);} .cxi-toolbar .ctrl.leave:hover::after,.cxi-toolbar .ctrl.leave:focus-visible::after{border-color:rgba(248,113,113,0.55);box-shadow:0 0 0 3px rgba(248,113,113,0.32);}
-@media (max-width:680px){.call-instructions{position:fixed;top:auto;bottom:18px;left:50%;transform:translateX(-50%);width:min(320px,94vw);padding:14px 16px;}}
+.cxi-gallery{display:grid;grid-template-columns:repeat(2,1fr);gap:12px;padding:18px;background:rgba(9,14,30,.82);} .cxi-gallery .tile{background:radial-gradient(140% 140% at 0% 0%,rgba(32,45,92,.86),rgba(11,18,40,.95) 70%);border:1px solid rgba(96,109,181,.25);border-radius:16px;aspect-ratio:16/9;position:relative;overflow:hidden;} .cxi-gallery .badge{position:absolute;left:12px;bottom:12px;background:rgba(12,18,38,.72);color:#e6edff;padding:4px 10px;border-radius:999px;font-size:.82rem;border:1px solid rgba(255,255,255,.18);}
+.cxi-toolbar{display:flex;align-items:center;gap:10px;padding:14px 18px;background:rgba(12,18,38,.92);border-top:1px solid rgba(148,163,184,.16);} .cxi-toolbar .ctrl{background:rgba(13,20,44,.92);color:#dbe3f8;border:1px solid rgba(80,102,176,.45);padding:10px 14px;border-radius:14px;cursor:pointer;position:relative;font-weight:600;font-size:.92rem;box-shadow:inset 0 0 0 1px rgba(90,113,204,.12);} .cxi-toolbar .ctrl::after{content:"";position:absolute;inset:-4px;border-radius:16px;border:2px solid transparent;pointer-events:none;transition:border-color .18s ease,box-shadow .18s ease;} .cxi-toolbar .ctrl:hover{background:rgba(17,26,56,.92);} .cxi-toolbar .ctrl:hover::after{border-color:rgba(96,165,250,.4);box-shadow:0 0 0 2px rgba(59,130,246,.18);} .cxi-toolbar .ctrl:focus-visible::after{border-color:rgba(148,197,255,.8);box-shadow:0 0 0 3px rgba(96,165,250,.35);} .cxi-toolbar .ctrl.leave{background:linear-gradient(120deg,rgba(248,113,113,.9),rgba(244,63,94,.92));border-color:rgba(248,113,113,.8);color:#fff4f4;font-weight:700;box-shadow:0 14px 28px rgba(248,113,113,.35);} .cxi-toolbar .ctrl.leave:hover{background:linear-gradient(120deg,rgba(239,68,68,.95),rgba(220,38,38,.92));} .cxi-toolbar .ctrl.leave:hover::after,.cxi-toolbar .ctrl.leave:focus-visible::after{border-color:rgba(248,180,180,.75);box-shadow:0 0 0 3px rgba(248,113,113,.32);}
+@media (max-width:680px){.interview-container{padding:12px;}.cxi-meeting{border-radius:18px;}.call-instructions{position:fixed;top:auto;bottom:18px;left:50%;transform:translateX(-50%);width:min(320px,94vw);padding:16px 18px 20px;}}
 
 /* Button hover/press affordance */
 .btn, .cxi-btn, .rating-btn, .aspect-btn, .ctrl { transition: transform .08s ease, box-shadow .12s ease, background-color .12s ease, border-color .12s ease; }
@@ -39,3 +70,177 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;b
 #results-view .results-card { padding: 1rem; }
 #results-view .results-grid { gap: 1rem; }
 #results-view .score-value { font-size: 2.4rem; }
+body[data-stage="results"]{background:var(--gradient-results);}
+.call-instructions button.dismiss{position:absolute;top:10px;right:10px;width:26px;height:26px;border-radius:999px;border:1px solid rgba(125,211,252,.4);background:rgba(9,14,30,.6);color:#cbd5f5;font-size:.8rem;cursor:pointer;transition:transform .25s ease,border-color .25s ease;}
+.call-instructions button.dismiss:hover{transform:scale(1.08);border-color:rgba(125,211,252,.8);}
+.cxi-gallery .tile::after{content:"";position:absolute;inset:0;background:linear-gradient(120deg,rgba(124,92,255,.18),transparent 55%);opacity:0;transition:opacity .4s ease;}
+.cxi-gallery .tile:hover::after{opacity:1;}
+.btn,.cxi-btn,.rating-btn,.aspect-btn,.ctrl{transition:transform .12s ease,box-shadow .16s ease,background-color .16s ease,border-color .16s ease;}
+.btn:hover,.cxi-btn:hover,.rating-btn:hover,.aspect-btn:hover,.ctrl:hover{transform:translateY(-1px);}
+.score-reveal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:clamp(24px,6vw,48px);background:rgba(5,7,20,.8);backdrop-filter:blur(26px);z-index:10020;opacity:0;pointer-events:none;transition:opacity .45s ease;}
+.score-reveal.is-visible{opacity:1;pointer-events:auto;}
+.score-reveal__panel{position:relative;width:min(760px,94vw);padding:clamp(28px,4vw,42px);border-radius:26px;border:1px solid rgba(124,92,255,.35);background:radial-gradient(circle at 0% 0%,rgba(124,92,255,.18),transparent 55%),linear-gradient(135deg,rgba(15,23,42,.95),rgba(8,13,32,.92));box-shadow:0 26px 64px rgba(3,9,28,.68);overflow:hidden;}
+.score-reveal__panel::before{content:"";position:absolute;inset:-40%;background:conic-gradient(from 120deg,rgba(124,92,255,.15),rgba(59,130,246,.1),rgba(34,197,94,.16),rgba(124,92,255,.12));opacity:0;animation:hero-flash 1.8s ease forwards;pointer-events:none;}
+.score-reveal__close{position:absolute;top:16px;right:16px;width:34px;height:34px;border-radius:999px;border:1px solid rgba(148,163,184,.38);background:rgba(10,16,32,.72);color:#cbd5f5;font-size:1.2rem;cursor:pointer;transition:transform .2s ease, border-color .2s ease;}
+.score-reveal__close:hover{transform:scale(1.08);border-color:rgba(148,197,255,.85);}
+.score-reveal__eyebrow{display:inline-flex;align-items:center;gap:8px;text-transform:uppercase;letter-spacing:.16em;font-size:.72rem;color:rgba(165,180,252,.9);margin-bottom:.5rem;}
+.score-reveal__eyebrow::before{content:"";width:32px;height:1px;background:linear-gradient(90deg,rgba(148,197,255,.65),transparent);}
+.score-reveal__headline{font-size:clamp(1.6rem,3.4vw,2.2rem);color:#f8fbff;margin-bottom:1.2rem;}
+.score-reveal__grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:14px;margin-bottom:1.4rem;}
+.score-reveal__metric{background:rgba(12,18,36,.82);border:1px solid rgba(148,163,184,.22);border-radius:18px;padding:14px 18px;box-shadow:0 18px 34px rgba(8,13,32,.45);text-align:center;}
+.score-reveal__metric .label{display:block;font-size:.72rem;text-transform:uppercase;letter-spacing:.12em;color:rgba(191,219,254,.74);margin-bottom:.4rem;}
+.score-reveal__metric .value{font-size:1.9rem;font-weight:700;color:#f8fbff;}
+.score-reveal__metric .value[data-reveal-nss]{font-variant-numeric:tabular-nums;font-size:1.8rem;}
+.score-reveal__summary{font-size:1rem;line-height:1.6;color:rgba(226,232,255,.88);background:rgba(9,14,30,.68);border-radius:16px;padding:16px 18px;border:1px solid rgba(148,163,184,.18);box-shadow:inset 0 0 0 1px rgba(96,165,250,.14);transition:box-shadow .3s ease;}
+.score-reveal__summary.is-highlighted{box-shadow:0 0 0 1px rgba(59,130,246,.45),0 0 30px rgba(59,130,246,.28);}
+.score-reveal__stage{display:flex;align-items:center;gap:12px;margin-top:1.2rem;font-size:.88rem;color:rgba(165,180,252,.85);text-transform:uppercase;letter-spacing:.12em;}
+.score-reveal__stage .band-pill{padding:.35rem .75rem;border-radius:999px;background:rgba(34,197,94,.22);border:1px solid rgba(34,197,94,.32);color:#bbf7d0;font-weight:700;}
+.score-reveal__aspects{display:flex;flex-wrap:wrap;gap:10px;margin-top:1.4rem;}
+.score-reveal__aspects span{padding:.45rem .85rem;border-radius:999px;border:1px solid rgba(148,163,184,.24);background:rgba(14,21,41,.8);color:#e0e7ff;font-size:.82rem;font-weight:600;box-shadow:0 10px 24px rgba(8,13,32,.38);}
+.score-reveal__sentence{margin-top:1.4rem;font-family:var(--font-mono);font-size:.95rem;line-height:1.7;background:rgba(8,13,32,.82);border-radius:16px;padding:16px 18px;border:1px solid rgba(148,163,184,.2);color:rgba(203,213,225,.85);min-height:82px;}
+.score-reveal__sentence mark{background:rgba(124,92,255,.35);color:#f8fafc;padding:2px 4px;border-radius:6px;transition:background .3s ease,color .3s ease;}
+.score-reveal__actions{margin-top:1.6rem;display:flex;flex-wrap:wrap;gap:12px;justify-content:flex-end;}
+.score-reveal__actions .btn{min-width:160px;}
+@media (max-width:640px){
+  .score-reveal__grid{grid-template-columns:repeat(2,minmax(120px,1fr));}
+  .score-reveal__actions{justify-content:center;}
+}
+.btn:active,.cxi-btn:active,.rating-btn:active,.aspect-btn:active,.ctrl:active,
+.btn.pressed,.cxi-btn.pressed,.rating-btn.pressed,.aspect-btn.pressed,.ctrl.pressed{transform:translateY(0);box-shadow:inset 0 2px 0 rgba(0,0,0,.12);}
+textarea,
+input[type="text"],
+input[type="email"],
+select{background:
+    radial-gradient(140% 120% at 0% 0%,rgba(124,92,255,.16),transparent 62%),
+    linear-gradient(135deg,rgba(17,24,39,.96),rgba(10,18,36,.92));
+  border:1px solid rgba(148,163,184,.34);
+  border-radius:16px;
+  padding:.95rem 1.1rem;
+  color:#f8fbff;
+  font-family:var(--font-display);
+  box-shadow:0 16px 36px rgba(9,15,30,.46),inset 0 0 0 1px rgba(99,102,241,.18);
+  transition:border-color .24s ease,box-shadow .24s ease,background-position .38s ease;
+  background-size:140% 140%,100% 100%;
+}
+textarea:hover,
+input[type="text"]:hover,
+input[type="email"]:hover,
+select:hover{background-position:10% 12%,0 0;}
+textarea:focus,
+input[type="text"]:focus,
+input[type="email"]:focus,
+select:focus{outline:none;border-color:rgba(124,92,255,.88);box-shadow:0 0 0 3px rgba(124,92,255,.28),0 22px 44px rgba(11,20,44,.55);}
+textarea{min-height:120px;max-height:240px;overflow-y:auto;line-height:1.55;resize:vertical;}
+textarea::placeholder,
+input[type="text"]::placeholder,
+input[type="email"]::placeholder{color:rgba(226,232,255,.65);letter-spacing:.02em;}
+textarea::-webkit-scrollbar,.transcript-playback::-webkit-scrollbar,#export-preview pre::-webkit-scrollbar{width:8px;height:8px;}
+textarea::-webkit-scrollbar-thumb,.transcript-playback::-webkit-scrollbar-thumb,#export-preview pre::-webkit-scrollbar-thumb{background:rgba(124,92,255,.38);border-radius:8px;}
+.results-container{min-height:100vh;padding:clamp(40px,6vw,72px) clamp(24px,6vw,72px) 96px;display:flex;flex-direction:column;gap:24px;align-items:center;justify-content:flex-start;position:relative;}
+.results-header{text-align:center;max-width:720px;}
+.results-header h1{font-size:clamp(2.1rem,3vw,2.8rem);color:#f8fbff;margin-bottom:.35rem;text-shadow:0 18px 42px rgba(5,9,24,.55);}
+.results-header p{color:rgba(226,232,255,.76);font-size:1rem;}
+.navigation-tabs{background:rgba(12,18,38,.62);border-radius:999px;padding:6px;border:1px solid rgba(148,163,184,.2);box-shadow:0 18px 40px rgba(6,11,28,.45);}
+.navigation-tabs div{display:flex;gap:8px;justify-content:center;flex-wrap:wrap;}
+.navigation-tabs button{border-radius:999px;padding:10px 22px;font-weight:600;color:rgba(226,232,255,.66);background:transparent;}
+.navigation-tabs button.active{background:linear-gradient(120deg,rgba(124,92,255,.92),rgba(98,224,255,.82));color:#0a1026;box-shadow:0 12px 24px rgba(124,92,255,.4);}
+.results-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:clamp(18px,3vw,32px);width:min(1200px,100%);}
+.results-card{background:var(--card);border-radius:var(--radius);padding:clamp(20px,3vw,28px);border:1px solid rgba(148,163,184,.18);box-shadow:var(--shadow-soft);backdrop-filter:blur(24px);position:relative;overflow:hidden;}
+.results-card.highlight-card{background:linear-gradient(140deg,rgba(124,92,255,.32),rgba(17,24,54,.88));}
+.results-card.highlight-card::after{content:"";position:absolute;inset:-40% -10% auto -10%;height:70%;background:radial-gradient(circle at 30% 40%,rgba(98,224,255,.35),transparent 65%);opacity:.8;pointer-events:none;}
+.score-display{text-align:center;margin-bottom:1.4rem;position:relative;}
+.score-value{font-size:clamp(2.4rem,4vw,3.4rem);font-weight:800;margin:1rem 0 .35rem;color:#fff;text-shadow:0 14px 32px rgba(15,23,42,.6);}
+.score-label{color:rgba(226,232,255,.65);font-size:.78rem;text-transform:uppercase;letter-spacing:.12em;}
+.band-indicator{display:inline-flex;align-items:center;gap:6px;padding:.5rem 1.1rem;border-radius:999px;font-weight:600;font-size:.88rem;}
+.band-success{background:var(--gradient-positive);color:#052e16;}
+.band-caution{background:linear-gradient(120deg,rgba(250,204,21,.82),rgba(253,224,71,.66));color:#3b2602;}
+.band-risk{background:var(--gradient-risk);color:#fff5f4;}
+.results-hero{display:grid;grid-template-columns:minmax(220px,1fr) 1.2fr;gap:clamp(18px,3vw,32px);align-items:center;}
+.score-orb{position:relative;width:clamp(220px,30vw,280px);aspect-ratio:1;border-radius:50%;background:radial-gradient(circle at 30% 25%,rgba(255,255,255,.22),transparent 68%),radial-gradient(circle at 70% 80%,rgba(124,92,255,.85),rgba(71,63,197,.82));display:flex;align-items:center;justify-content:center;flex-direction:column;box-shadow:0 24px 54px rgba(79,70,229,.45);overflow:hidden;margin:0 auto;}
+.score-orb::after{content:"";position:absolute;inset:12%;border-radius:50%;border:1px solid rgba(255,255,255,.2);box-shadow:inset 0 0 40px rgba(255,255,255,.16);pointer-events:none;}
+.orb-value{font-size:clamp(2.6rem,5vw,3.6rem);font-weight:800;color:#fff;}
+.orb-label{font-size:.82rem;letter-spacing:.18em;text-transform:uppercase;margin-top:.75rem;color:rgba(244,244,255,.72);}
+.orb-band{margin-top:.4rem;font-size:.88rem;color:rgba(255,255,255,.9);}
+.orb-band span{padding:.2rem .65rem;border-radius:999px;background:rgba(15,23,42,.45);border:1px solid rgba(255,255,255,.2);}
+.hero-metric-grid{display:grid;gap:12px;}
+.metric-tile{background:rgba(13,21,44,.82);padding:14px 18px;border-radius:14px;border:1px solid rgba(148,163,184,.2);display:flex;justify-content:space-between;align-items:center;gap:12px;}
+.metric-tile .metric-label{font-size:.82rem;text-transform:uppercase;letter-spacing:.08em;color:rgba(226,232,255,.68);}
+.metric-tile .metric-value{font-size:1.6rem;font-weight:700;color:#f8fbff;}
+.transcript-playback{margin-top:1.4rem;padding:16px 18px;border-radius:14px;border:1px solid rgba(148,163,184,.16);background:rgba(6,10,24,.65);font-family:var(--font-mono);font-size:.92rem;max-height:160px;overflow-y:auto;line-height:1.6;box-shadow:inset 0 0 0 1px rgba(71,85,105,.16);}
+.transcript-playback span{display:inline;padding:.05rem .25rem;border-radius:6px;transition:background .35s ease,color .35s ease;}
+.transcript-playback span.active{background:rgba(56,189,248,.28);color:#f8fafc;box-shadow:0 0 0 2px rgba(56,189,248,.12);}
+.heatmap-container{width:min(1120px,100%);display:grid;gap:18px;}
+.heatmap-grid{display:grid;grid-template-columns:140px repeat(7,1fr);gap:10px;align-items:stretch;}
+.heatmap-row-label{display:flex;align-items:center;justify-content:flex-start;padding:12px 14px;background:rgba(12,18,36,.72);border-radius:12px;border:1px solid rgba(148,163,184,.18);font-weight:600;}
+.heatmap-cell{border-radius:12px;padding:12px 10px;font-weight:600;text-align:center;cursor:pointer;position:relative;overflow:hidden;border:1px solid transparent;transition:transform .18s ease,box-shadow .18s ease,border-color .18s ease;}
+.heatmap-cell.active{transform:translateY(-2px);border-color:rgba(59,130,246,.6);box-shadow:0 18px 32px rgba(14,23,42,.55);}
+.heatmap-cell::after{content:attr(data-label);position:absolute;inset:auto 6px 8px;font-size:.68rem;text-transform:uppercase;letter-spacing:.12em;color:rgba(15,23,42,.66);font-weight:700;}
+.heatmap-cell.heatmap-positive{background:var(--heat-positive);color:#22c55e;border-color:rgba(34,197,94,.3);}
+.heatmap-cell.heatmap-negative{background:var(--heat-negative);color:#fb7185;border-color:rgba(248,113,113,.35);}
+.heatmap-cell.heatmap-neutral{background:var(--heat-neutral);color:#facc15;border-color:rgba(250,204,21,.35);}
+.heatmap-cell:hover{transform:translateY(-4px);box-shadow:0 18px 36px rgba(12,18,36,.55);}
+.task-list{display:grid;gap:14px;}
+.task-item{padding:18px;border-radius:16px;background:rgba(12,20,42,.76);border:1px solid rgba(148,163,184,.2);box-shadow:var(--shadow-soft);transition:transform .2s ease,box-shadow .2s ease;}
+.task-item:hover{transform:translateY(-4px);box-shadow:0 20px 40px rgba(11,18,34,.5);}
+.task-meta{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap;}
+.task-priority{font-size:.8rem;padding:.35rem .75rem;border-radius:999px;text-transform:uppercase;letter-spacing:.08em;font-weight:700;}
+.priority-high{background:rgba(251,113,133,.28);color:#fecdd3;}
+.priority-medium{background:rgba(250,204,21,.28);color:#fef3c7;}
+.priority-low{background:rgba(34,197,94,.28);color:#dcfce7;}
+.roster-card ul{list-style:none;display:grid;gap:12px;margin-top:12px;}
+.roster-card li{display:flex;flex-direction:column;gap:6px;background:rgba(12,18,36,.72);padding:12px 14px;border-radius:12px;border:1px solid rgba(148,163,184,.16);}
+.roster-card .name{font-weight:700;color:#f8fbff;}
+.roster-card .goal{font-size:.88rem;color:rgba(226,232,255,.72);}
+.export-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;}
+.export-pre{background:rgba(6,10,24,.8);padding:1.2rem;border-radius:14px;border:1px solid rgba(148,163,184,.2);color:rgba(226,232,255,.86);font-family:var(--font-mono);max-height:360px;overflow:auto;}
+.share-preview{margin-top:12px;padding:14px;border-radius:12px;background:rgba(5,9,24,.72);border:1px solid rgba(96,165,250,.26);font-family:var(--font-mono);font-size:.9rem;white-space:pre-wrap;color:rgba(226,232,255,.84);}
+.share-buttons{display:flex;flex-wrap:wrap;gap:10px;}
+.share-buttons .btn{flex:1;min-width:140px;}
+.toast-layer{position:fixed;bottom:24px;right:24px;display:grid;gap:12px;z-index:9999;}
+.toast{background:rgba(12,18,36,.92);border-radius:14px;padding:12px 16px;border:1px solid rgba(96,165,250,.25);box-shadow:0 18px 32px rgba(11,18,34,.55);animation:toast-in .35s ease;display:flex;gap:10px;align-items:center;}
+.toast[data-tone="positive"]{border-color:rgba(74,222,128,.35);}
+.toast[data-tone="warning"]{border-color:rgba(250,204,21,.35);}
+.toast button.toast-close{background:transparent;border:none;color:rgba(226,232,255,.7);font-size:1rem;cursor:pointer;}
+@keyframes toast-in{from{opacity:0;transform:translateY(12px) scale(.96);}to{opacity:1;transform:translateY(0) scale(1);}}
+@keyframes fade-in-up{from{opacity:0;transform:translateY(10px);}to{opacity:1;transform:translateY(0);}}
+.modal-overlay{position:fixed;inset:0;background:rgba(5,8,20,.78);backdrop-filter:blur(18px);display:flex;align-items:center;justify-content:center;z-index:9998;opacity:0;pointer-events:none;transition:opacity .3s ease;}
+.modal-overlay.is-visible{opacity:1;pointer-events:auto;}
+.modal-overlay .modal-panel{background:rgba(8,13,32,.95);border-radius:20px;border:1px solid rgba(124,92,255,.35);padding:clamp(24px,4vw,32px);width:min(720px,94vw);box-shadow:0 24px 60px rgba(8,13,32,.68);display:grid;gap:18px;}
+.modal-panel header{display:flex;justify-content:space-between;align-items:center;gap:16px;}
+.modal-panel header h3{font-size:1.4rem;}
+.modal-panel .modal-body{display:grid;gap:18px;}
+.modal-panel footer{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap;}
+.checklist{display:grid;gap:12px;}
+.checklist .checklist-item{display:flex;align-items:flex-start;gap:12px;background:rgba(12,18,36,.72);padding:12px 14px;border-radius:12px;border:1px solid rgba(148,163,184,.18);cursor:pointer;transition:border-color .2s ease,box-shadow .2s ease;}
+.checklist .checklist-item:hover{border-color:rgba(124,92,255,.45);box-shadow:0 14px 30px rgba(11,18,34,.45);}
+.checklist .checklist-item strong{display:block;font-size:1rem;line-height:1.4;color:#f8fbff;}
+.checklist .checklist-item em{display:block;font-style:normal;font-size:.92rem;color:rgba(226,232,255,.75);margin-top:2px;}
+.checklist .checklist-item small{display:block;font-size:.78rem;color:rgba(148,163,184,.82);margin-top:6px;}
+.checklist input[type="checkbox"]{margin-top:4px;accent-color:#7c5cff;}
+.chip{display:inline-flex;align-items:center;gap:6px;padding:.3rem .65rem;border-radius:999px;font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;margin-top:6px;}
+.chip-high{background:rgba(239,68,68,.18);color:#fca5a5;border:1px solid rgba(248,113,113,.35);}
+.chip-medium{background:rgba(250,204,21,.18);color:#facc15;border:1px solid rgba(250,204,21,.35);}
+.chip-low{background:rgba(34,197,94,.18);color:#4ade80;border:1px solid rgba(34,197,94,.32);}
+.score-pill{display:inline-flex;align-items:center;gap:8px;padding:.45rem .85rem;border-radius:999px;font-weight:700;text-transform:uppercase;font-size:.78rem;letter-spacing:.08em;}
+.score-positive{background:rgba(34,197,94,.22);color:#4ade80;border:1px solid rgba(34,197,94,.35);}
+.score-negative{background:rgba(248,113,113,.22);color:#fca5a5;border:1px solid rgba(248,113,113,.35);}
+.score-neutral{background:rgba(250,204,21,.22);color:#facc15;border:1px solid rgba(250,204,21,.35);}
+.insight-list{list-style:none;padding:0;margin:6px 0 0;display:grid;gap:8px;}
+.insight-list li{background:rgba(12,18,36,.68);border-radius:10px;padding:10px 12px;border:1px solid rgba(148,163,184,.16);line-height:1.5;color:rgba(226,232,255,.86);}
+.insight-list mark{background:rgba(56,189,248,.25);color:#f8fafc;padding:0 4px;border-radius:4px;}
+.roster-card.pulse{animation:roster-pulse 1.4s ease;}
+@keyframes roster-pulse{0%{box-shadow:0 0 0 0 rgba(124,92,255,.4);}100%{box-shadow:0 0 0 24px rgba(124,92,255,0);}}
+.modal-overlay.visible,.modal-overlay.is-visible{opacity:1;pointer-events:auto;}
+.ats-panel{position:fixed;bottom:24px;right:24px;background:rgba(8,13,32,.92);border-radius:18px;border:1px solid rgba(124,92,255,.35);width:min(360px,90vw);box-shadow:0 24px 54px rgba(8,13,32,.6);overflow:hidden;z-index:999;}
+.ats-panel .hdr{padding:14px 18px;display:flex;justify-content:space-between;align-items:center;font-weight:700;}
+.ats-panel .act{padding:12px 18px;display:flex;align-items:center;gap:12px;border-top:1px solid rgba(148,163,184,.16);}
+.ats-panel .payload-preview{padding:16px 18px 20px;display:grid;gap:10px;}
+.ats-panel .payload-preview .row{display:flex;justify-content:space-between;font-size:.84rem;color:rgba(226,232,255,.75);}
+.ats-panel pre{margin-top:8px;max-height:160px;overflow:auto;background:rgba(5,9,24,.68);border-radius:14px;padding:12px;border:1px solid rgba(148,163,184,.18);font-family:var(--font-mono);font-size:.75rem;color:rgba(226,232,255,.7);}
+.results-card.celebrate::before,.results-card.celebrate::after{content:"";position:absolute;inset:-20%;background:conic-gradient(from 180deg,rgba(124,92,255,.15),rgba(59,130,246,.1),rgba(34,197,94,.15),rgba(124,92,255,.15));opacity:0;animation:hero-flash 1.6s ease forwards;pointer-events:none;}
+@keyframes hero-flash{0%{opacity:0;transform:scale(.8) rotate(-8deg);}60%{opacity:.65;transform:scale(1.02) rotate(0deg);}100%{opacity:0;transform:scale(1.1) rotate(12deg);}}
+@media (max-width:960px){.results-hero{grid-template-columns:1fr;justify-items:center;}.score-orb{width:clamp(200px,40vw,260px);}}
+@media (max-width:720px){.navigation-tabs{width:100%;}.navigation-tabs div{display:flex;flex-wrap:wrap;gap:8px;justify-content:center;}}
+#results-view .results-card{padding:clamp(20px,3vw,28px);}
+#results-view .results-grid{gap:clamp(18px,3vw,32px);}
+#results-view .score-value{font-size:clamp(2.4rem,4vw,3.4rem);}


### PR DESCRIPTION
## Summary
- add an animated score reveal overlay that spotlights composite metrics, highlights transcript context, and guides the presenter into the dashboard
- refresh inline instructions and survey inputs with pauseable auto-dismiss logic and richer gradient styling so the meeting chrome stays legible without zooming
- hide the ATS dead-letter controls unless ?debug=1 to keep the public demo focused on the magical reveal

## Testing
- npm run test:quick
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dca773b5288320a61119ec30d72ba9