### PR TITLE
Improve dashboard evidence highlighting

### DIFF
--- a/dist/js/js/dashboard.js
+++ b/dist/js/js/dashboard.js
@@ -287,22 +287,30 @@ function extractEvidence(aspect) {
     ];
   }
   const keywords = aspectKeywords[aspect] || [aspect];
+  const sortedKeywords = [...keywords].sort((a, b) => b.length - a.length);
+  const escapeRegex = (kw) => String(kw || "").replace(/[-\\^$*+?.()|[\]{}]/g, "\\$&");
+  const escapedKeywords = sortedKeywords.map(escapeRegex).filter(Boolean);
+  const allKeywordsRegex = escapedKeywords.length
+    ? new RegExp(`(${escapedKeywords.join("|")})`, "gi")
+    : null;
   const sentences = text.split(/(?<=[.!?])\s+/);
   const matches = [];
+  const tempDiv = document.createElement("div");
   sentences.forEach((sentence) => {
-    const lower = sentence.toLowerCase();
-    if (keywords.some((kw) => lower.includes(kw))) {
-      let highlighted = sentence;
-      keywords.forEach((kw) => {
-        const reg = new RegExp(`(${kw})`, "gi");
-        highlighted = highlighted.replace(reg, '<mark>$1</mark>');
-      });
+    tempDiv.textContent = sentence;
+    const sanitized = tempDiv.innerHTML;
+    if (!allKeywordsRegex) {
+      return;
+    }
+    const highlighted = sanitized.replace(allKeywordsRegex, '<mark>$1</mark>');
+    if (highlighted !== sanitized) {
       matches.push(highlighted);
     }
   });
   if (!matches.length) {
     const first = sentences[0] || text;
-    return [first];
+    tempDiv.textContent = first;
+    return [tempDiv.innerHTML];
   }
   return matches.slice(0, 3);
 }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -287,22 +287,30 @@ function extractEvidence(aspect) {
     ];
   }
   const keywords = aspectKeywords[aspect] || [aspect];
+  const sortedKeywords = [...keywords].sort((a, b) => b.length - a.length);
+  const escapeRegex = (kw) => String(kw || "").replace(/[-\\^$*+?.()|[\]{}]/g, "\\$&");
+  const escapedKeywords = sortedKeywords.map(escapeRegex).filter(Boolean);
+  const allKeywordsRegex = escapedKeywords.length
+    ? new RegExp(`(${escapedKeywords.join("|")})`, "gi")
+    : null;
   const sentences = text.split(/(?<=[.!?])\s+/);
   const matches = [];
+  const tempDiv = document.createElement("div");
   sentences.forEach((sentence) => {
-    const lower = sentence.toLowerCase();
-    if (keywords.some((kw) => lower.includes(kw))) {
-      let highlighted = sentence;
-      keywords.forEach((kw) => {
-        const reg = new RegExp(`(${kw})`, "gi");
-        highlighted = highlighted.replace(reg, '<mark>$1</mark>');
-      });
+    tempDiv.textContent = sentence;
+    const sanitized = tempDiv.innerHTML;
+    if (!allKeywordsRegex) {
+      return;
+    }
+    const highlighted = sanitized.replace(allKeywordsRegex, '<mark>$1</mark>');
+    if (highlighted !== sanitized) {
       matches.push(highlighted);
     }
   });
   if (!matches.length) {
     const first = sentences[0] || text;
-    return [first];
+    tempDiv.textContent = first;
+    return [tempDiv.innerHTML];
   }
   return matches.slice(0, 3);
 }


### PR DESCRIPTION
## Summary
- build a single escaped keyword regex for dashboard evidence highlighting and sanitize each sentence before adding markup
- mirror the updated highlighting logic in the built distribution bundle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3131f93c083208f14a33609e4650f